### PR TITLE
feat: auto-sync recipes on login + phone screen UI tests

### DIFF
--- a/androidApp/src/test/kotlin/com/ultraviolince/mykitchen/RecipeListScreenTest.kt
+++ b/androidApp/src/test/kotlin/com/ultraviolince/mykitchen/RecipeListScreenTest.kt
@@ -1,0 +1,80 @@
+package com.ultraviolince.mykitchen
+
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import com.ultraviolince.mykitchen.domain.model.Recipe
+import com.ultraviolince.mykitchen.domain.model.RecipeOrder
+import com.ultraviolince.mykitchen.ui.screens.recipelist.RecipeListScreenContent
+import com.ultraviolince.mykitchen.ui.screens.recipelist.RecipeListState
+import com.ultraviolince.mykitchen.ui.theme.AppTheme
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.setResourceReaderAndroidContext
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(ScreenshotTestRunner::class)
+class RecipeListScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @OptIn(ExperimentalResourceApi::class)
+    @Test
+    fun withRecipes_topBarSyncAndLogoutAndItemsVisible() {
+        composeTestRule.setContent {
+            val ctx = LocalContext.current
+            remember(ctx) { setResourceReaderAndroidContext(ctx) }
+            AppTheme {
+                RecipeListScreenContent(
+                    state = RecipeListState(
+                        recipes = listOf(
+                            Recipe(id = "1", title = "Pasta Carbonara", content = "Classic pasta", timestamp = 0L),
+                            Recipe(id = "2", title = "Chocolate Cake", content = "Rich cake", timestamp = 0L),
+                        ),
+                        order = RecipeOrder.Date(),
+                    ),
+                    onAddRecipe = {},
+                    onEditRecipe = {},
+                    onSync = {},
+                    onLogout = {},
+                    onDelete = {},
+                    onOrderChange = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("Sync").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Logout").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Pasta Carbonara").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Chocolate Cake").assertIsDisplayed()
+    }
+
+    @OptIn(ExperimentalResourceApi::class)
+    @Test
+    fun emptyState_topBarAndNoRecipesTextVisible() {
+        composeTestRule.setContent {
+            val ctx = LocalContext.current
+            remember(ctx) { setResourceReaderAndroidContext(ctx) }
+            AppTheme {
+                RecipeListScreenContent(
+                    state = RecipeListState(),
+                    onAddRecipe = {},
+                    onEditRecipe = {},
+                    onSync = {},
+                    onLogout = {},
+                    onDelete = {},
+                    onOrderChange = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("Sync").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Logout").assertIsDisplayed()
+        composeTestRule.onNodeWithText("No recipes yet. Tap + to add one.").assertIsDisplayed()
+    }
+}

--- a/androidApp/src/test/screenshots/com.ultraviolince.mykitchen.ui.screens.recipelist.RecipeListScreenPreviewsKt.RecipeListScreenPhonePreview.Phone_—_Recipe_List_W360dp_H800dp_WITH_BACKGROUND.png
+++ b/androidApp/src/test/screenshots/com.ultraviolince.mykitchen.ui.screens.recipelist.RecipeListScreenPreviewsKt.RecipeListScreenPhonePreview.Phone_—_Recipe_List_W360dp_H800dp_WITH_BACKGROUND.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:978ac97e514ae4c113fbb92dcf5d41c03da19631a99ef76602e5834b4aecbb52
+size 62554

--- a/shared/ui/src/androidMain/kotlin/com/ultraviolince/mykitchen/ui/screens/recipelist/RecipeListScreenPreviews.kt
+++ b/shared/ui/src/androidMain/kotlin/com/ultraviolince/mykitchen/ui/screens/recipelist/RecipeListScreenPreviews.kt
@@ -53,3 +53,29 @@ internal fun RecipeListScreenWithItemsPreview() {
         )
     }
 }
+
+@OptIn(ExperimentalResourceApi::class)
+@Preview(showBackground = true, name = "Phone — Recipe List", widthDp = 360, heightDp = 800)
+@Composable
+internal fun RecipeListScreenPhonePreview() {
+    val ctx = LocalContext.current
+    remember(ctx) { setResourceReaderAndroidContext(ctx) }
+    AppTheme {
+        RecipeListScreenContent(
+            state = RecipeListState(
+                recipes = listOf(
+                    Recipe(id = "1", title = "Pasta Carbonara", content = "Classic Italian pasta dish", timestamp = 0L),
+                    Recipe(id = "2", title = "Chocolate Cake", content = "Rich and decadent cake", timestamp = 0L),
+                    Recipe(id = "3", title = "Caesar Salad", content = "Fresh and crispy", timestamp = 0L),
+                ),
+                order = RecipeOrder.Date(),
+            ),
+            onAddRecipe = {},
+            onEditRecipe = {},
+            onSync = {},
+            onLogout = {},
+            onDelete = {},
+            onOrderChange = {},
+        )
+    }
+}

--- a/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/recipelist/RecipeListScreen.kt
+++ b/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/recipelist/RecipeListScreen.kt
@@ -66,8 +66,9 @@ fun RecipeListScreen(
     val authState by viewModel.authState.collectAsState()
 
     LaunchedEffect(authState) {
-        if (authState is AuthState.LoggedOut) {
-            onNavigateToLogin()
+        when (authState) {
+            is AuthState.LoggedOut -> onNavigateToLogin()
+            is AuthState.LoggedIn -> viewModel.sync()
         }
     }
 
@@ -84,7 +85,7 @@ fun RecipeListScreen(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-internal fun RecipeListScreenContent(
+fun RecipeListScreenContent(
     state: RecipeListState,
     onAddRecipe: () -> Unit,
     onEditRecipe: (String) -> Unit,


### PR DESCRIPTION
## Summary

- **Auto-sync**: `RecipeListScreen` now calls `viewModel.sync()` when `authState` transitions to `LoggedIn`, so recipes load immediately after login without requiring a manual tap of the sync button. Fixes the empty recipe list on the WasmJs web app (in-memory DAO starts empty on every page load).
- **UI tests**: Two new Robolectric/Compose tests in `RecipeListScreenTest` assert that the TopAppBar sync button, logout button, recipe items, and empty-state text are all displayed on a phone-sized screen.
- **Phone preview**: Added `@Preview(widthDp=360, heightDp=800)` to `RecipeListScreenPreviews` — Roborazzi captures a golden for explicit phone layout regression.
- **Visibility**: `RecipeListScreenContent` changed from `internal` to public so it can be tested directly without a ViewModel (Compose best practice).

## Test plan
- [ ] Log in at `https://kitchen.ultraviolince.com` — recipes should appear without pressing sync
- [ ] CI passes: Tests, Verify Screenshots, Docker Image

🤖 Generated with [Claude Code](https://claude.com/claude-code)