### PR TITLE
fix(android): enable resValues build feature for snapshot app name

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -75,6 +75,12 @@ android {
     namespace = "com.ultraviolince.mykitchen"
     compileSdk = libs.versions.compileSdk.get().toInt()
 
+    buildFeatures {
+        // AGP 9.x disables resValues by default; the release build type uses resValue()
+        // for the snapshot app name, so this must be explicitly enabled.
+        resValues = true
+    }
+
     val keystorePropertiesFile = rootProject.file("keystore.properties")
     val keystoreProperties = Properties()
     if (keystorePropertiesFile.exists()) {


### PR DESCRIPTION
## Summary
- AGP 9.x disables the `resValues` build feature by default
- The `release` build type calls `resValue("string", "app_name", "Kitchen on fire!")` when `snapshotBuild=true` (i.e., every RC build triggered by CI)
- This causes the Release workflow to fail immediately during project configuration with: `Build Type release contains custom resource values, but the feature is disabled.`
- Fix: add `buildFeatures { resValues = true }` to the `android {}` block in `androidApp/build.gradle.kts`

## Root cause
The Release workflow calls:
```
./gradlew :androidApp:assembleRelease -PsnapshotBuild=true
```
This triggers the `resValue()` call in the release build type, but AGP 9.x no longer enables this feature by default — it must be opted in explicitly.

## Test plan
- [ ] CI Release workflow runs green on this branch ("Build APK for release candidate" step)
- [ ] Debug builds unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)