### PR TITLE
ci: auto-update PR branches on push to main

### DIFF
--- a/.github/workflows/update-pr-branches.yml
+++ b/.github/workflows/update-pr-branches.yml
@@ -1,0 +1,35 @@
+name: Auto-update PR branches
+
+on:
+  push:
+    branches: [ main ]
+
+concurrency:
+  group: auto-update-prs
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update open PR branches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          OWNER="${{ github.repository_owner }}"
+          gh pr list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --json number,headRepositoryOwner \
+            | jq -r --arg owner "$OWNER" \
+              '.[] | select(.headRepositoryOwner.login == $owner) | .number' \
+            | while read -r pr_number; do
+                echo "Updating PR #$pr_number"
+                gh pr update-branch "$pr_number" \
+                  --repo "${{ github.repository }}" \
+                  || echo "PR #$pr_number: skipped (already up to date or conflict)"
+              done


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/update-pr-branches.yml` that triggers on every push to `main`
- Calls `gh pr update-branch` for all open PRs whose head branch lives in the same repo (forks are skipped)
- Replaces the need to manually click "Update branch" for each PR after merging to main

## How it works

On push to `main`, the workflow lists all open PRs, filters to same-repo branches only (skips external contributor forks), and merges `main` into each. If a PR is already up to date or has a merge conflict, the step logs it and continues rather than failing the whole run.

## Test plan

- [ ] Merge something to `main` and verify the workflow triggers and updates open PRs
- [ ] Verify a PR from a fork is skipped without error
- [ ] Verify a PR with a merge conflict logs a skip message rather than failing the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)