### PR TITLE
fix(desktop): sanitize packageVersion for native distributions

### DIFF
--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -25,7 +25,12 @@ compose.desktop {
                 org.jetbrains.compose.desktop.application.dsl.TargetFormat.Deb,
             )
             packageName = "My Kitchen"
-            packageVersion = project.findProperty("versionName")?.toString() ?: "1.0.0"
+            // Deb/Dmg/Msi require a numeric-only version (no leading 'v', no pre-release suffix).
+            // Strip the 'v' prefix and everything from the first '-' onward: "v0.6.9-rc" → "0.6.9".
+            packageVersion = (project.findProperty("versionName")?.toString() ?: "1.0.0")
+                .removePrefix("v")
+                .substringBefore("-")
+                .ifBlank { "1.0.0" }
         }
     }
 }


### PR DESCRIPTION
## Summary
- After the `resValues` fix landed, the Release workflow now fails at a second issue: `:desktopApp` configuration rejects `v0.6.9-rc` as a `packageVersion`
- Deb requires `UPSTREAM_VERSION` to start with a digit (no leading `v`)
- Dmg requires `MAJOR[.MINOR][.PATCH]` (no pre-release suffix)
- The workflow passes `-PversionName=v0.6.9-rc` for RC builds, which propagates directly into `nativeDistributions.packageVersion`

## Fix
Sanitize the version before using it as `packageVersion`:
```kotlin
packageVersion = (project.findProperty("versionName")?.toString() ?: "1.0.0")
    .removePrefix("v")
    .substringBefore("-")
    .ifBlank { "1.0.0" }
```
`v0.6.9-rc` → `0.6.9`; `v1.2.3` → `1.2.3`; no property → `1.0.0`

## Local verification
Reproduced and fixed locally:
- `./gradlew :desktopApp:tasks -PversionName=v0.6.9-rc` → BUILD SUCCESSFUL
- `./gradlew :desktopApp:tasks -PversionName=v1.2.3` → BUILD SUCCESSFUL
- `./gradlew :desktopApp:tasks` (no property) → BUILD SUCCESSFUL

## Test plan
- [ ] Release workflow on main passes the "Build APK for release candidate" step
- [ ] Desktop tasks configure without error when `versionName` contains a pre-release suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)