### PR TITLE
feat: persist login credentials across app restarts

### DIFF
--- a/shared/data/src/androidMain/kotlin/com/ultraviolince/mykitchen/data/di/PlatformDataModule.kt
+++ b/shared/data/src/androidMain/kotlin/com/ultraviolince/mykitchen/data/di/PlatformDataModule.kt
@@ -6,6 +6,8 @@ import com.ultraviolince.mykitchen.data.local.RecipeDao
 import com.ultraviolince.mykitchen.data.local.RecipeDatabase
 import com.ultraviolince.mykitchen.data.local.RoomRecipeDaoAdapter
 import com.ultraviolince.mykitchen.data.local.getDatabaseBuilder
+import com.ultraviolince.mykitchen.data.store.CredentialsStore
+import com.ultraviolince.mykitchen.data.store.SharedPreferencesCredentialsStore
 import kotlinx.coroutines.Dispatchers
 import org.koin.dsl.module
 
@@ -17,5 +19,6 @@ actual val platformDataModule = module {
             .build()
     }
     single<RecipeDao> { RoomRecipeDaoAdapter(get<RecipeDatabase>().recipeRoomDao()) }
+    single<CredentialsStore> { SharedPreferencesCredentialsStore(get()) }
 }
 

--- a/shared/data/src/androidMain/kotlin/com/ultraviolince/mykitchen/data/store/SharedPreferencesCredentialsStore.kt
+++ b/shared/data/src/androidMain/kotlin/com/ultraviolince/mykitchen/data/store/SharedPreferencesCredentialsStore.kt
@@ -1,0 +1,41 @@
+package com.ultraviolince.mykitchen.data.store
+
+import android.content.Context
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+
+class SharedPreferencesCredentialsStore(context: Context) : CredentialsStore {
+    private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    private data class Credentials(val token: String, val serverUrl: String)
+
+    private val state = MutableStateFlow(loadFromPrefs())
+
+    private fun loadFromPrefs(): Credentials? {
+        val token = prefs.getString(KEY_TOKEN, null) ?: return null
+        val serverUrl = prefs.getString(KEY_SERVER_URL, null) ?: return null
+        return Credentials(token, serverUrl)
+    }
+
+    override fun observeToken(): Flow<String?> = state.map { it?.token }
+    override fun observeServerUrl(): Flow<String?> = state.map { it?.serverUrl }
+    override suspend fun getToken(): String? = state.value?.token
+    override suspend fun getServerUrl(): String? = state.value?.serverUrl
+
+    override suspend fun saveCredentials(token: String, serverUrl: String) {
+        prefs.edit().putString(KEY_TOKEN, token).putString(KEY_SERVER_URL, serverUrl).apply()
+        state.value = Credentials(token, serverUrl)
+    }
+
+    override suspend fun clearCredentials() {
+        prefs.edit().remove(KEY_TOKEN).remove(KEY_SERVER_URL).apply()
+        state.value = null
+    }
+
+    companion object {
+        private const val PREFS_NAME = "credentials"
+        private const val KEY_TOKEN = "token"
+        private const val KEY_SERVER_URL = "server_url"
+    }
+}

--- a/shared/data/src/commonMain/kotlin/com/ultraviolince/mykitchen/data/di/DataModule.kt
+++ b/shared/data/src/commonMain/kotlin/com/ultraviolince/mykitchen/data/di/DataModule.kt
@@ -2,8 +2,6 @@ package com.ultraviolince.mykitchen.data.di
 
 import com.ultraviolince.mykitchen.data.remote.RecipeApiClient
 import com.ultraviolince.mykitchen.data.repository.RecipeRepositoryImpl
-import com.ultraviolince.mykitchen.data.store.CredentialsStore
-import com.ultraviolince.mykitchen.data.store.InMemoryCredentialsStore
 import com.ultraviolince.mykitchen.domain.repository.RecipeRepository
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -22,6 +20,5 @@ val dataModule = module {
         }
     }
     single { RecipeApiClient(get()) }
-    single<CredentialsStore> { InMemoryCredentialsStore() }
     single<RecipeRepository> { RecipeRepositoryImpl(get(), get(), get()) }
 }

--- a/shared/data/src/desktopMain/kotlin/com/ultraviolince/mykitchen/data/di/PlatformDataModule.kt
+++ b/shared/data/src/desktopMain/kotlin/com/ultraviolince/mykitchen/data/di/PlatformDataModule.kt
@@ -5,6 +5,8 @@ import com.ultraviolince.mykitchen.data.local.RecipeDao
 import com.ultraviolince.mykitchen.data.local.RecipeDatabase
 import com.ultraviolince.mykitchen.data.local.RoomRecipeDaoAdapter
 import com.ultraviolince.mykitchen.data.local.getDatabaseBuilder
+import com.ultraviolince.mykitchen.data.store.CredentialsStore
+import com.ultraviolince.mykitchen.data.store.DesktopCredentialsStore
 import kotlinx.coroutines.Dispatchers
 import org.koin.dsl.module
 
@@ -16,5 +18,6 @@ actual val platformDataModule = module {
             .build()
     }
     single<RecipeDao> { RoomRecipeDaoAdapter(get<RecipeDatabase>().recipeRoomDao()) }
+    single<CredentialsStore> { DesktopCredentialsStore() }
 }
 

--- a/shared/data/src/desktopMain/kotlin/com/ultraviolince/mykitchen/data/store/DesktopCredentialsStore.kt
+++ b/shared/data/src/desktopMain/kotlin/com/ultraviolince/mykitchen/data/store/DesktopCredentialsStore.kt
@@ -1,0 +1,42 @@
+package com.ultraviolince.mykitchen.data.store
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import java.util.prefs.Preferences
+
+class DesktopCredentialsStore : CredentialsStore {
+    private val prefs = Preferences.userNodeForPackage(DesktopCredentialsStore::class.java)
+
+    private data class Credentials(val token: String, val serverUrl: String)
+
+    private val state = MutableStateFlow(loadFromPrefs())
+
+    private fun loadFromPrefs(): Credentials? {
+        val token = prefs.get(KEY_TOKEN, null) ?: return null
+        val serverUrl = prefs.get(KEY_SERVER_URL, null) ?: return null
+        return Credentials(token, serverUrl)
+    }
+
+    override fun observeToken(): Flow<String?> = state.map { it?.token }
+    override fun observeServerUrl(): Flow<String?> = state.map { it?.serverUrl }
+    override suspend fun getToken(): String? = state.value?.token
+    override suspend fun getServerUrl(): String? = state.value?.serverUrl
+
+    override suspend fun saveCredentials(token: String, serverUrl: String) {
+        prefs.put(KEY_TOKEN, token)
+        prefs.put(KEY_SERVER_URL, serverUrl)
+        state.value = Credentials(token, serverUrl)
+    }
+
+    override suspend fun clearCredentials() {
+        prefs.remove(KEY_TOKEN)
+        prefs.remove(KEY_SERVER_URL)
+        state.value = null
+    }
+
+    companion object {
+        private const val KEY_TOKEN = "token"
+        private const val KEY_SERVER_URL = "server_url"
+    }
+}

--- a/shared/data/src/iosMain/kotlin/com/ultraviolince/mykitchen/data/di/PlatformDataModule.kt
+++ b/shared/data/src/iosMain/kotlin/com/ultraviolince/mykitchen/data/di/PlatformDataModule.kt
@@ -5,6 +5,8 @@ import com.ultraviolince.mykitchen.data.local.RecipeDao
 import com.ultraviolince.mykitchen.data.local.RecipeDatabase
 import com.ultraviolince.mykitchen.data.local.RoomRecipeDaoAdapter
 import com.ultraviolince.mykitchen.data.local.getDatabaseBuilder
+import com.ultraviolince.mykitchen.data.store.CredentialsStore
+import com.ultraviolince.mykitchen.data.store.IosCredentialsStore
 import kotlinx.coroutines.Dispatchers
 import org.koin.dsl.module
 
@@ -16,5 +18,6 @@ actual val platformDataModule = module {
             .build()
     }
     single<RecipeDao> { RoomRecipeDaoAdapter(get<RecipeDatabase>().recipeRoomDao()) }
+    single<CredentialsStore> { IosCredentialsStore() }
 }
 

--- a/shared/data/src/iosMain/kotlin/com/ultraviolince/mykitchen/data/store/IosCredentialsStore.kt
+++ b/shared/data/src/iosMain/kotlin/com/ultraviolince/mykitchen/data/store/IosCredentialsStore.kt
@@ -1,0 +1,42 @@
+package com.ultraviolince.mykitchen.data.store
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import platform.Foundation.NSUserDefaults
+
+class IosCredentialsStore : CredentialsStore {
+    private val defaults = NSUserDefaults.standardUserDefaults
+
+    private data class Credentials(val token: String, val serverUrl: String)
+
+    private val state = MutableStateFlow(loadFromDefaults())
+
+    private fun loadFromDefaults(): Credentials? {
+        val token = defaults.stringForKey(KEY_TOKEN) ?: return null
+        val serverUrl = defaults.stringForKey(KEY_SERVER_URL) ?: return null
+        return Credentials(token, serverUrl)
+    }
+
+    override fun observeToken(): Flow<String?> = state.map { it?.token }
+    override fun observeServerUrl(): Flow<String?> = state.map { it?.serverUrl }
+    override suspend fun getToken(): String? = state.value?.token
+    override suspend fun getServerUrl(): String? = state.value?.serverUrl
+
+    override suspend fun saveCredentials(token: String, serverUrl: String) {
+        defaults.setObject(token, KEY_TOKEN)
+        defaults.setObject(serverUrl, KEY_SERVER_URL)
+        state.value = Credentials(token, serverUrl)
+    }
+
+    override suspend fun clearCredentials() {
+        defaults.removeObjectForKey(KEY_TOKEN)
+        defaults.removeObjectForKey(KEY_SERVER_URL)
+        state.value = null
+    }
+
+    companion object {
+        private const val KEY_TOKEN = "credentials_token"
+        private const val KEY_SERVER_URL = "credentials_server_url"
+    }
+}

--- a/shared/data/src/wasmJsMain/kotlin/com/ultraviolince/mykitchen/data/di/PlatformDataModule.kt
+++ b/shared/data/src/wasmJsMain/kotlin/com/ultraviolince/mykitchen/data/di/PlatformDataModule.kt
@@ -2,8 +2,11 @@ package com.ultraviolince.mykitchen.data.di
 
 import com.ultraviolince.mykitchen.data.local.InMemoryRecipeDao
 import com.ultraviolince.mykitchen.data.local.RecipeDao
+import com.ultraviolince.mykitchen.data.store.CredentialsStore
+import com.ultraviolince.mykitchen.data.store.InMemoryCredentialsStore
 import org.koin.dsl.module
 
 actual val platformDataModule = module {
     single<RecipeDao> { InMemoryRecipeDao() }
+    single<CredentialsStore> { InMemoryCredentialsStore() }
 }


### PR DESCRIPTION
## Summary

- Replace `InMemoryCredentialsStore` (credentials lost on restart) with platform-specific persistent implementations
- **Android**: `SharedPreferencesCredentialsStore` — backed by `SharedPreferences`
- **Desktop**: `DesktopCredentialsStore` — backed by `java.util.prefs.Preferences`
- **iOS**: `IosCredentialsStore` — backed by `NSUserDefaults`
- **Web (wasmJs)**: keeps `InMemoryCredentialsStore`, consistent with the existing in-memory recipe DAO on that platform

## Test plan

- [ ] Android: log in, kill and reopen app — should go directly to recipe list without login prompt
- [ ] Desktop: log in, close and reopen app — should go directly to recipe list without login prompt
- [ ] iOS: log in, kill and reopen app — should go directly to recipe list without login prompt
- [ ] Logout still clears credentials on all platforms
- [ ] CI green: `build`, `web`, `ios`, `instrumentedtests`, `verify-screenshots`, `backend-image`

🤖 Generated with [Claude Code](https://claude.com/claude-code)