### PR TITLE
fix(web): persist login credentials using localStorage

### DIFF
--- a/shared/data/src/wasmJsMain/kotlin/com/ultraviolince/mykitchen/data/di/PlatformDataModule.kt
+++ b/shared/data/src/wasmJsMain/kotlin/com/ultraviolince/mykitchen/data/di/PlatformDataModule.kt
@@ -3,10 +3,10 @@ package com.ultraviolince.mykitchen.data.di
 import com.ultraviolince.mykitchen.data.local.InMemoryRecipeDao
 import com.ultraviolince.mykitchen.data.local.RecipeDao
 import com.ultraviolince.mykitchen.data.store.CredentialsStore
-import com.ultraviolince.mykitchen.data.store.InMemoryCredentialsStore
+import com.ultraviolince.mykitchen.data.store.WebCredentialsStore
 import org.koin.dsl.module
 
 actual val platformDataModule = module {
     single<RecipeDao> { InMemoryRecipeDao() }
-    single<CredentialsStore> { InMemoryCredentialsStore() }
+    single<CredentialsStore> { WebCredentialsStore() }
 }

--- a/shared/data/src/wasmJsMain/kotlin/com/ultraviolince/mykitchen/data/store/WebCredentialsStore.kt
+++ b/shared/data/src/wasmJsMain/kotlin/com/ultraviolince/mykitchen/data/store/WebCredentialsStore.kt
@@ -1,0 +1,40 @@
+package com.ultraviolince.mykitchen.data.store
+
+import kotlinx.browser.localStorage
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+
+class WebCredentialsStore : CredentialsStore {
+    private data class Credentials(val token: String, val serverUrl: String)
+
+    private val state = MutableStateFlow(loadFromStorage())
+
+    private fun loadFromStorage(): Credentials? {
+        val token = localStorage.getItem(KEY_TOKEN) ?: return null
+        val serverUrl = localStorage.getItem(KEY_SERVER_URL) ?: return null
+        return Credentials(token, serverUrl)
+    }
+
+    override fun observeToken(): Flow<String?> = state.map { it?.token }
+    override fun observeServerUrl(): Flow<String?> = state.map { it?.serverUrl }
+    override suspend fun getToken(): String? = state.value?.token
+    override suspend fun getServerUrl(): String? = state.value?.serverUrl
+
+    override suspend fun saveCredentials(token: String, serverUrl: String) {
+        localStorage.setItem(KEY_TOKEN, token)
+        localStorage.setItem(KEY_SERVER_URL, serverUrl)
+        state.value = Credentials(token, serverUrl)
+    }
+
+    override suspend fun clearCredentials() {
+        localStorage.removeItem(KEY_TOKEN)
+        localStorage.removeItem(KEY_SERVER_URL)
+        state.value = null
+    }
+
+    companion object {
+        private const val KEY_TOKEN = "token"
+        private const val KEY_SERVER_URL = "server_url"
+    }
+}


### PR DESCRIPTION
## Summary

- The web platform was using `InMemoryCredentialsStore`, which stores the auth token and server URL in-memory only — losing them on every page reload
- Added `WebCredentialsStore` that persists credentials to `window.localStorage`, matching the pattern used by Android (`SharedPreferencesCredentialsStore`) and Desktop (`DesktopCredentialsStore`)
- Wired it up in `wasmJsMain/PlatformDataModule` replacing `InMemoryCredentialsStore`

## Root cause

`feat/persistent-credentials-store` added persistence for Android and Desktop but the web platform (`wasmJsMain`) was left with the in-memory fallback, so every page load required re-entering credentials and server URL.

## Test plan

- [ ] CI `web` job builds the WasmJs distribution with the new store
- [ ] CI `build` job passes (detekt, domain/data unit tests, coverage)
- [ ] Manual: open web app → log in → reload page → credentials and server URL should be restored automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)