### PR TITLE
fix: clickable enrichment links and tag filtering in the recipe list

### DIFF
--- a/androidApp/src/test/kotlin/com/ultraviolince/mykitchen/RecipeListScreenTest.kt
+++ b/androidApp/src/test/kotlin/com/ultraviolince/mykitchen/RecipeListScreenTest.kt
@@ -44,6 +44,7 @@ class RecipeListScreenTest {
                     onLogout = {},
                     onDelete = {},
                     onOrderChange = {},
+                    onTagSelect = {},
                 )
             }
         }
@@ -69,6 +70,7 @@ class RecipeListScreenTest {
                     onLogout = {},
                     onDelete = {},
                     onOrderChange = {},
+                    onTagSelect = {},
                 )
             }
         }

--- a/androidApp/src/test/screenshots/com.ultraviolince.mykitchen.ui.screens.recipelist.RecipeListScreenPreviewsKt.RecipeListScreenWithItemsPreview.Recipe_List_With_Items_WITH_BACKGROUND.png
+++ b/androidApp/src/test/screenshots/com.ultraviolince.mykitchen.ui.screens.recipelist.RecipeListScreenPreviewsKt.RecipeListScreenWithItemsPreview.Recipe_List_With_Items_WITH_BACKGROUND.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7467bf1d17be9e20c539ac5f06a004890846bcc3855eebf082ae2dd5bf729266
-size 55253
+oid sha256:c63957c699493742a14e0a4fe9ce6f52867e4bf6bd85ebb5a808f97a019b7075
+size 65155

--- a/server/src/main/kotlin/com/ultraviolince/mykitchen/server/routes/EnrichmentRoutes.kt
+++ b/server/src/main/kotlin/com/ultraviolince/mykitchen/server/routes/EnrichmentRoutes.kt
@@ -30,7 +30,20 @@ fun Route.enrichmentRoutes() {
         route("/recipes/{recipeId}/enrichment") {
             get { call.handleGetEnrichment() }
         }
+        // All enrichments of the current user in one call, so the recipe list
+        // can offer tag filtering without one request per recipe.
+        get("/enrichments") { call.handleGetAllEnrichments() }
     }
+}
+
+private suspend fun io.ktor.server.application.ApplicationCall.handleGetAllEnrichments() {
+    val userId = userIdOrUnauthorized() ?: return
+    val enrichments = transaction {
+        RecipeEnrichments.selectAll()
+            .where { RecipeEnrichments.userId eq UUID.fromString(userId) }
+            .map { it.toEnrichmentDto() }
+    }
+    respond(enrichments)
 }
 
 private suspend fun io.ktor.server.application.ApplicationCall.handleGetEnrichment() {

--- a/server/src/test/kotlin/com/ultraviolince/mykitchen/server/EnrichmentRoutesTest.kt
+++ b/server/src/test/kotlin/com/ultraviolince/mykitchen/server/EnrichmentRoutesTest.kt
@@ -147,6 +147,40 @@ class EnrichmentRoutesTest {
     }
 
     @Test
+    fun listEnrichmentsRequiresAuth() = testApp {
+        val response = client.get("/enrichments")
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun listEnrichmentsReturnsEmptyListWhenNoneExist() = testApp {
+        val response = client.get("/enrichments") { bearerAuth(token) }
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(emptyList(), response.body<List<JsonObject>>())
+    }
+
+    @Test
+    fun listEnrichmentsReturnsOnlyOwnEnrichments() = testApp {
+        seedEnrichment(recipeId)
+        // A second user with their own enriched recipe must not leak in.
+        UserRepository.create("other@test.com", "password123")
+        val otherToken = client.post("/users/login") {
+            contentType(ContentType.Application.Json)
+            setBody(LoginBody("other@test.com", "password123"))
+        }.body<JsonObject>()["token"]!!.jsonPrimitive.content
+        val otherRecipeId = client.post("/recipes") {
+            bearerAuth(otherToken)
+            contentType(ContentType.Application.Json)
+            setBody(RecipeBody("Soup", "Boil water"))
+        }.body<JsonObject>()["id"]!!.jsonPrimitive.content
+        seedEnrichment(otherRecipeId, summary = "Other dish")
+
+        val body = client.get("/enrichments") { bearerAuth(token) }.body<List<JsonObject>>()
+        assertEquals(1, body.size)
+        assertEquals("A tasty dish", body.first()["summary"]!!.jsonPrimitive.content)
+    }
+
+    @Test
     fun deletingRecipeAlsoRemovesItsEnrichment() = testApp {
         seedEnrichment(recipeId)
         val response = client.delete("/recipes/$recipeId") { bearerAuth(token) }

--- a/shared/data/src/commonMain/kotlin/com/ultraviolince/mykitchen/data/remote/EnrichmentApiClient.kt
+++ b/shared/data/src/commonMain/kotlin/com/ultraviolince/mykitchen/data/remote/EnrichmentApiClient.kt
@@ -20,4 +20,12 @@ class EnrichmentApiClient(private val httpClient: HttpClient) {
             }
             if (response.status == HttpStatusCode.NotFound) null else response.body<EnrichmentDto>()
         }
+
+    /** All enrichments of the current user — one call, for tag filtering in the list. */
+    suspend fun getEnrichments(serverUrl: String, token: String): Result<List<EnrichmentDto>> =
+        runCatching {
+            httpClient.get("$serverUrl/enrichments") {
+                bearerAuth(token)
+            }.body<List<EnrichmentDto>>()
+        }
 }

--- a/shared/data/src/commonMain/kotlin/com/ultraviolince/mykitchen/data/repository/EnrichmentRepositoryImpl.kt
+++ b/shared/data/src/commonMain/kotlin/com/ultraviolince/mykitchen/data/repository/EnrichmentRepositoryImpl.kt
@@ -18,4 +18,12 @@ class EnrichmentRepositoryImpl(
             ?: return Result.failure(IllegalStateException("Not logged in"))
         return api.getEnrichment(serverUrl, token, recipeId).map { it?.toDomain() }
     }
+
+    override suspend fun getEnrichments(): Result<List<RecipeEnrichment>> {
+        val token = credentials.getToken()
+            ?: return Result.failure(IllegalStateException("Not logged in"))
+        val serverUrl = credentials.getServerUrl()
+            ?: return Result.failure(IllegalStateException("Not logged in"))
+        return api.getEnrichments(serverUrl, token).map { list -> list.map { it.toDomain() } }
+    }
 }

--- a/shared/data/src/commonTest/kotlin/com/ultraviolince/mykitchen/data/fake/FakeEnrichmentApiClientFactory.kt
+++ b/shared/data/src/commonTest/kotlin/com/ultraviolince/mykitchen/data/fake/FakeEnrichmentApiClientFactory.kt
@@ -19,10 +19,11 @@ fun buildMockEnrichmentApiClient(
          "tags":["quick"],"links":[],"summary":"Tasty","updated_at":1000}
     """.trimIndent(),
 ): EnrichmentApiClient {
-    val engine = MockEngine { _ ->
+    val engine = MockEngine { request ->
         if (succeeds) {
+            val body = if (request.url.encodedPath.endsWith("/enrichments")) "[$enrichmentJson]" else enrichmentJson
             respond(
-                content = enrichmentJson,
+                content = body,
                 status = HttpStatusCode.OK,
                 headers = headersOf(HttpHeaders.ContentType, "application/json"),
             )

--- a/shared/data/src/commonTest/kotlin/com/ultraviolince/mykitchen/data/remote/EnrichmentApiClientTest.kt
+++ b/shared/data/src/commonTest/kotlin/com/ultraviolince/mykitchen/data/remote/EnrichmentApiClientTest.kt
@@ -55,6 +55,31 @@ class EnrichmentApiClientTest {
     }
 
     @Test
+    fun getEnrichmentsReturnsListOnSuccess() = runTest {
+        val engine = MockEngine { _ ->
+            respond(
+                content = "[$enrichmentJson]",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = EnrichmentApiClient(buildClient(engine))
+        val result = client.getEnrichments("http://localhost:5000", "tok")
+        assertTrue(result.isSuccess)
+        assertEquals(1, result.getOrNull()?.size)
+    }
+
+    @Test
+    fun getEnrichmentsReturnsFailureOnServerError() = runTest {
+        val engine = MockEngine { _ ->
+            respond(content = """{"error":"boom"}""", status = HttpStatusCode.InternalServerError)
+        }
+        val client = EnrichmentApiClient(buildClient(engine))
+        val result = client.getEnrichments("http://localhost:5000", "tok")
+        assertTrue(result.isFailure)
+    }
+
+    @Test
     fun getEnrichmentReturnsFailureOnServerError() = runTest {
         val engine = MockEngine { _ ->
             respond(content = """{"error":"boom"}""", status = HttpStatusCode.InternalServerError)

--- a/shared/data/src/commonTest/kotlin/com/ultraviolince/mykitchen/data/repository/EnrichmentRepositoryImplTest.kt
+++ b/shared/data/src/commonTest/kotlin/com/ultraviolince/mykitchen/data/repository/EnrichmentRepositoryImplTest.kt
@@ -42,4 +42,19 @@ class EnrichmentRepositoryImplTest {
         val result = repo.getEnrichment("recipe-1")
         assertTrue(result.isFailure)
     }
+
+    @Test
+    fun getEnrichmentsReturnsListWhenLoggedIn() = runTest {
+        val repo = buildRepo()
+        val result = repo.getEnrichments()
+        assertTrue(result.isSuccess)
+        assertEquals(listOf("enr-1"), result.getOrNull()?.map { it.id })
+    }
+
+    @Test
+    fun getEnrichmentsFailsWhenNotLoggedIn() = runTest {
+        val repo = buildRepo(loggedIn = false)
+        val result = repo.getEnrichments()
+        assertTrue(result.isFailure)
+    }
 }

--- a/shared/domain/src/commonMain/kotlin/com/ultraviolince/mykitchen/domain/di/DomainModule.kt
+++ b/shared/domain/src/commonMain/kotlin/com/ultraviolince/mykitchen/domain/di/DomainModule.kt
@@ -4,6 +4,7 @@ import com.ultraviolince.mykitchen.domain.usecase.AddRecipeUseCase
 import com.ultraviolince.mykitchen.domain.usecase.DeleteRecipeUseCase
 import com.ultraviolince.mykitchen.domain.usecase.GetAuthStateUseCase
 import com.ultraviolince.mykitchen.domain.usecase.GetEnrichmentUseCase
+import com.ultraviolince.mykitchen.domain.usecase.GetEnrichmentsUseCase
 import com.ultraviolince.mykitchen.domain.usecase.GetRecipeUseCase
 import com.ultraviolince.mykitchen.domain.usecase.GetRecipesUseCase
 import com.ultraviolince.mykitchen.domain.usecase.LoginUseCase
@@ -21,4 +22,5 @@ val domainModule = module {
     factory { LogoutUseCase(get()) }
     factory { GetAuthStateUseCase(get()) }
     factory { GetEnrichmentUseCase(get()) }
+    factory { GetEnrichmentsUseCase(get()) }
 }

--- a/shared/domain/src/commonMain/kotlin/com/ultraviolince/mykitchen/domain/repository/EnrichmentRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/com/ultraviolince/mykitchen/domain/repository/EnrichmentRepository.kt
@@ -4,4 +4,5 @@ import com.ultraviolince.mykitchen.domain.model.RecipeEnrichment
 
 interface EnrichmentRepository {
     suspend fun getEnrichment(recipeId: String): Result<RecipeEnrichment?>
+    suspend fun getEnrichments(): Result<List<RecipeEnrichment>>
 }

--- a/shared/domain/src/commonMain/kotlin/com/ultraviolince/mykitchen/domain/usecase/GetEnrichmentsUseCase.kt
+++ b/shared/domain/src/commonMain/kotlin/com/ultraviolince/mykitchen/domain/usecase/GetEnrichmentsUseCase.kt
@@ -1,0 +1,7 @@
+package com.ultraviolince.mykitchen.domain.usecase
+
+import com.ultraviolince.mykitchen.domain.repository.EnrichmentRepository
+
+class GetEnrichmentsUseCase(private val repository: EnrichmentRepository) {
+    suspend operator fun invoke() = repository.getEnrichments()
+}

--- a/shared/ui/src/androidMain/kotlin/com/ultraviolince/mykitchen/ui/screens/recipelist/RecipeListScreenPreviews.kt
+++ b/shared/ui/src/androidMain/kotlin/com/ultraviolince/mykitchen/ui/screens/recipelist/RecipeListScreenPreviews.kt
@@ -25,6 +25,7 @@ internal fun RecipeListScreenEmptyPreview() {
             onLogout = {},
             onDelete = {},
             onOrderChange = {},
+            onTagSelect = {},
         )
     }
 }
@@ -43,6 +44,10 @@ internal fun RecipeListScreenWithItemsPreview() {
                     Recipe(id = "2", title = "Chocolate Cake", content = "Rich and decadent cake", timestamp = 0L),
                 ),
                 order = RecipeOrder.Title(),
+                tagsByRecipe = mapOf(
+                    "1" to listOf("quick", "budget-friendly"),
+                    "2" to listOf("kids-friendly"),
+                ),
             ),
             onAddRecipe = {},
             onEditRecipe = {},
@@ -50,6 +55,7 @@ internal fun RecipeListScreenWithItemsPreview() {
             onLogout = {},
             onDelete = {},
             onOrderChange = {},
+            onTagSelect = {},
         )
     }
 }
@@ -76,6 +82,7 @@ internal fun RecipeListScreenPhonePreview() {
             onLogout = {},
             onDelete = {},
             onOrderChange = {},
+            onTagSelect = {},
         )
     }
 }

--- a/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/addedit/BeautifiedRecipeView.kt
+++ b/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/addedit/BeautifiedRecipeView.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.ultraviolince.mykitchen.domain.model.RecipeEnrichment
@@ -101,7 +102,11 @@ internal fun BeautifiedRecipeView(
 
 @Composable
 private fun RecipeLinkCard(link: RecipeLink) {
-    Card(modifier = Modifier.fillMaxWidth()) {
+    val uriHandler = LocalUriHandler.current
+    Card(
+        onClick = { uriHandler.openUri(link.url) },
+        modifier = Modifier.fillMaxWidth(),
+    ) {
         Column(modifier = Modifier.padding(12.dp)) {
             Text(link.title, style = MaterialTheme.typography.titleSmall)
             Spacer(modifier = Modifier.height(4.dp))

--- a/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/recipelist/RecipeListScreen.kt
+++ b/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/recipelist/RecipeListScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ExitToApp
@@ -19,6 +20,7 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -80,6 +82,7 @@ fun RecipeListScreen(
         onLogout = viewModel::logout,
         onDelete = viewModel::delete,
         onOrderChange = viewModel::setOrder,
+        onTagSelect = viewModel::selectTag,
     )
 }
 
@@ -93,6 +96,7 @@ fun RecipeListScreenContent(
     onLogout: () -> Unit,
     onDelete: (String) -> Unit,
     onOrderChange: (RecipeOrder) -> Unit,
+    onTagSelect: (String?) -> Unit,
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -134,7 +138,14 @@ fun RecipeListScreenContent(
                 currentOrder = state.order,
                 onOrderChange = onOrderChange,
             )
-            if (state.recipes.isEmpty()) {
+            if (state.allTags.isNotEmpty()) {
+                TagFilterRow(
+                    tags = state.allTags,
+                    selectedTag = state.selectedTag,
+                    onTagSelect = onTagSelect,
+                )
+            }
+            if (state.visibleRecipes.isEmpty()) {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     Text(stringResource(Res.string.no_recipes), style = MaterialTheme.typography.bodyLarge)
                 }
@@ -143,7 +154,7 @@ fun RecipeListScreenContent(
                     contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    items(state.recipes, key = { it.id }) { recipe ->
+                    items(state.visibleRecipes, key = { it.id }) { recipe ->
                         RecipeItem(
                             recipe = recipe,
                             onClick = { onEditRecipe(recipe.id) },
@@ -152,6 +163,26 @@ fun RecipeListScreenContent(
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun TagFilterRow(
+    tags: List<String>,
+    selectedTag: String?,
+    onTagSelect: (String?) -> Unit,
+) {
+    LazyRow(
+        contentPadding = PaddingValues(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        items(tags, key = { it }) { tag ->
+            FilterChip(
+                selected = tag == selectedTag,
+                onClick = { onTagSelect(tag) },
+                label = { Text(tag) },
+            )
         }
     }
 }

--- a/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/recipelist/RecipeListViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/recipelist/RecipeListViewModel.kt
@@ -7,6 +7,7 @@ import com.ultraviolince.mykitchen.domain.model.Recipe
 import com.ultraviolince.mykitchen.domain.model.RecipeOrder
 import com.ultraviolince.mykitchen.domain.usecase.DeleteRecipeUseCase
 import com.ultraviolince.mykitchen.domain.usecase.GetAuthStateUseCase
+import com.ultraviolince.mykitchen.domain.usecase.GetEnrichmentsUseCase
 import com.ultraviolince.mykitchen.domain.usecase.GetRecipesUseCase
 import com.ultraviolince.mykitchen.domain.usecase.LogoutUseCase
 import com.ultraviolince.mykitchen.domain.usecase.SyncRecipesUseCase
@@ -26,7 +27,20 @@ data class RecipeListState(
     val order: RecipeOrder = RecipeOrder.Date(),
     val isSyncing: Boolean = false,
     val error: StringResource? = null,
-)
+    /** Tags of each recipe's server-generated enrichment, keyed by recipe id. */
+    val tagsByRecipe: Map<String, List<String>> = emptyMap(),
+    val selectedTag: String? = null,
+) {
+    /** Distinct tags across all enrichments, for the filter chip row. */
+    val allTags: List<String>
+        get() = tagsByRecipe.values.flatten().distinct().sorted()
+
+    /** Recipes to display, respecting the selected tag filter. */
+    val visibleRecipes: List<Recipe>
+        get() = selectedTag?.let { tag ->
+            recipes.filter { tagsByRecipe[it.id]?.contains(tag) == true }
+        } ?: recipes
+}
 
 class RecipeListViewModel(
     private val getRecipes: GetRecipesUseCase,
@@ -34,6 +48,7 @@ class RecipeListViewModel(
     private val syncRecipes: SyncRecipesUseCase,
     private val logout: LogoutUseCase,
     private val getAuthState: GetAuthStateUseCase,
+    private val getEnrichments: GetEnrichmentsUseCase,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(RecipeListState())
@@ -44,6 +59,7 @@ class RecipeListViewModel(
 
     init {
         collectRecipes(RecipeOrder.Date())
+        loadEnrichmentTags()
     }
 
     private fun collectRecipes(order: RecipeOrder) {
@@ -54,8 +70,21 @@ class RecipeListViewModel(
         }
     }
 
+    private fun loadEnrichmentTags() {
+        viewModelScope.launch {
+            val enrichments = getEnrichments().getOrNull() ?: return@launch
+            _state.update { state ->
+                state.copy(tagsByRecipe = enrichments.associate { it.recipeId to it.tags })
+            }
+        }
+    }
+
     fun setOrder(order: RecipeOrder) {
         collectRecipes(order)
+    }
+
+    fun selectTag(tag: String?) {
+        _state.update { it.copy(selectedTag = if (it.selectedTag == tag) null else tag) }
     }
 
     fun delete(id: String) {
@@ -74,6 +103,7 @@ class RecipeListViewModel(
                     error = if (result.isFailure) Res.string.error_sync_failed else null,
                 )
             }
+            loadEnrichmentTags()
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes two issues found while testing auto-beautify (#817) on Android:

1. **Links were not clickable.** The link cards in the beautified recipe view rendered as plain text. They now open the URL through `LocalUriHandler`, which works on Android, desktop, and web.
2. **Tags could not be used for search.** New `GET /enrichments` endpoint returns all of the user's enrichments in a single call. The recipe list now shows a horizontal filter-chip row with every tag; tapping a chip filters the list to recipes carrying that tag, tapping it again clears the filter. Tags refresh on sync.

## Tests

- Server: `EnrichmentRoutesTest` covers the new list endpoint (auth required, empty list, cross-user isolation).
- Client: `EnrichmentApiClientTest` / `EnrichmentRepositoryImplTest` cover the bulk fetch incl. failure paths.
- Ran locally: all JVM tests, detekt (incl. androidApp), koverVerify, Android compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)