### PR TITLE
fix(ui): surface delete recipe errors in RecipeListViewModel

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,7 +58,7 @@ minSdk = "28"
 targetSdk = "36"
 
 # Logging
-logback = "1.5.37"
+logback = "1.5.38"
 
 # AI / Media
 coil = "3.2.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.3.20"
 agp = "9.2.1"
-ksp = "2.3.9"
+ksp = "2.3.10"
 javaVersion = "17"
 
 # Compose

--- a/shared/ui/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/ui/src/commonMain/composeResources/values-de/strings.xml
@@ -47,6 +47,7 @@
     <string name="error_fields_required">Alle Felder sind erforderlich</string>
     <string name="error_title_required">Titel ist erforderlich</string>
     <string name="error_login_failed">Anmeldung fehlgeschlagen. Bitte überprüfen Sie Ihre Anmeldedaten.</string>
+    <string name="error_delete_failed">Löschen fehlgeschlagen. Bitte versuchen Sie es erneut.</string>
     <string name="error_sync_failed">Synchronisierung fehlgeschlagen. Bitte versuchen Sie es erneut.</string>
     <string name="error_beautify_failed">Rezept konnte nicht verschönert werden. Bitte versuchen Sie es erneut.</string>
     <string name="error_refine_failed">Verfeinerung konnte nicht angewendet werden. Bitte versuchen Sie es erneut.</string>

--- a/shared/ui/src/commonMain/composeResources/values/strings.xml
+++ b/shared/ui/src/commonMain/composeResources/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="error_fields_required">All fields are required</string>
     <string name="error_title_required">Title is required</string>
     <string name="error_login_failed">Login failed. Please check your credentials.</string>
+    <string name="error_delete_failed">Delete failed. Please try again.</string>
     <string name="error_sync_failed">Sync failed. Please try again.</string>
     <string name="error_beautify_failed">Could not beautify recipe. Please try again.</string>
     <string name="error_refine_failed">Could not apply refinement. Please try again.</string>

--- a/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/recipelist/RecipeListViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/recipelist/RecipeListViewModel.kt
@@ -11,6 +11,7 @@ import com.ultraviolince.mykitchen.domain.usecase.GetRecipesUseCase
 import com.ultraviolince.mykitchen.domain.usecase.LogoutUseCase
 import com.ultraviolince.mykitchen.domain.usecase.SyncRecipesUseCase
 import com.ultraviolince.mykitchen.ui.generated.resources.Res
+import com.ultraviolince.mykitchen.ui.generated.resources.error_delete_failed
 import com.ultraviolince.mykitchen.ui.generated.resources.error_sync_failed
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -60,7 +61,11 @@ class RecipeListViewModel(
 
     fun delete(id: String) {
         viewModelScope.launch {
-            deleteRecipe(id)
+            try {
+                deleteRecipe(id)
+            } catch (e: Exception) {
+                _state.update { it.copy(error = Res.string.error_delete_failed) }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- `delete()` in `RecipeListViewModel` launched a fire-and-forget coroutine with no error handling, silently swallowing failures.
- Added `try/catch` around the `deleteRecipe(id)` call that emits `error = Res.string.error_delete_failed` on failure.
- Added `error_delete_failed` string resource to both `values/strings.xml` (English) and `values-de/strings.xml` (German).
- The existing `RecipeListScreenContent` already observes `state.error` via `LaunchedEffect` and shows it in a `SnackbarHost`, so no UI changes were needed.

## Test plan

- [ ] Trigger a delete when the backend is unreachable and confirm a Snackbar appears with "Delete failed. Please try again."
- [ ] Trigger a successful delete and confirm no Snackbar appears.
- [ ] Verify CI passes (`build`, `web`, `ios`, `instrumentedtests`, `verify-screenshots`, `backend-image`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)