### PR TITLE
fix(server): restart AutoBeautifyWorker on crash with backoff

### DIFF
--- a/server/src/main/kotlin/com/ultraviolince/mykitchen/server/Application.kt
+++ b/server/src/main/kotlin/com/ultraviolince/mykitchen/server/Application.kt
@@ -16,7 +16,13 @@ import io.ktor.server.application.Application
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import io.ktor.server.routing.routing
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+import kotlin.math.min
+
+private val logger = LoggerFactory.getLogger("Application")
 
 fun main() {
     embeddedServer(Netty, port = 5000, host = "0.0.0.0") {
@@ -27,8 +33,34 @@ fun main() {
         configureStatusPages()
         configureCors(config)
         configureRouting(config)
-        launch { AutoBeautifyWorker(EnrichmentService(config)).run() }
+        launchAutoBeautifyWorker(EnrichmentService(config))
     }.start(wait = true)
+}
+
+/**
+ * Launches the [AutoBeautifyWorker] in the application scope with a supervised
+ * restart loop and exponential backoff. If the worker throws an uncaught
+ * exception it is logged at ERROR level and the worker is restarted after a
+ * delay (starting at [BACKOFF_INITIAL_MS], doubling each crash, capped at
+ * [BACKOFF_MAX_MS]).
+ */
+fun Application.launchAutoBeautifyWorker(enrichmentService: EnrichmentService) {
+    launch {
+        var backoffMs = BACKOFF_INITIAL_MS
+        while (true) {
+            try {
+                AutoBeautifyWorker(enrichmentService).run()
+                // run() exited normally (coroutine cancelled) — don't restart
+                break
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logger.error("AutoBeautifyWorker crashed, restarting in ${backoffMs / 1000}s", e)
+                delay(backoffMs)
+                backoffMs = min(backoffMs * 2, BACKOFF_MAX_MS)
+            }
+        }
+    }
 }
 
 fun Application.configureRouting(config: AppConfig) {
@@ -39,3 +71,6 @@ fun Application.configureRouting(config: AppConfig) {
         enrichmentRoutes()
     }
 }
+
+private const val BACKOFF_INITIAL_MS = 5_000L
+private const val BACKOFF_MAX_MS = 300_000L


### PR DESCRIPTION
## Summary
- Wraps `AutoBeautifyWorker` launch in a supervised retry loop with exponential backoff (5s initial, capped at 5min)
- Logs crashes at ERROR level before restarting so failures are visible in production logs
- Previously, an uncaught exception would kill the worker permanently with no restart and no log entry, silently stopping all recipe enrichment

Replaces #832, which had a merge conflict against `main` (that branch was accidentally based on a stale local `develop` ref that has since been merged and deleted). This is the same fix, rebased cleanly onto current `main`.

## Changes
- `server/Application.kt` — replaced bare `launch { worker.run() }` with `launchAutoBeautifyWorker()`, a supervised scope + retry loop with exponential backoff

## Test plan
- [ ] CI server tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)