### PR TITLE
feat: prefill login credentials via launch parameters

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -104,7 +104,10 @@ jobs:
       run: |
         ./gradlew :androidApp:assemblePreview \
           -PversionCode=${{ steps.release_info.outputs.version_code }} \
-          -PversionName=${{ steps.release_info.outputs.version_name }}
+          -PversionName=${{ steps.release_info.outputs.version_name }} \
+          -PpreviewUrl=${{ secrets.PREVIEW_URL }} \
+          -PpreviewUser=${{ secrets.PREVIEW_USER }} \
+          -PpreviewPass=${{ secrets.PREVIEW_PASS }}
 
     - name: Build APK for tag release
       if: steps.release_info.outputs.is_tag_release == 'true'

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -79,6 +79,7 @@ android {
         // AGP 9.x disables resValues by default; build types use resValue() for
         // per-variant app names, so this must be explicitly enabled.
         resValues = true
+        buildConfig = true
     }
 
     val keystorePropertiesFile = rootProject.file("keystore.properties")
@@ -105,6 +106,10 @@ android {
         versionCode = project.findProperty("versionCode")?.toString()?.toInt() ?: 1
         versionName = project.findProperty("versionName")?.toString() ?: "2.0.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        // Empty defaults so all build types always have these fields.
+        buildConfigField("String", "PREVIEW_SERVER_URL", "\"\"")
+        buildConfigField("String", "PREVIEW_EMAIL", "\"\"")
+        buildConfigField("String", "PREVIEW_PASSWORD", "\"\"")
     }
 
     buildTypes {
@@ -122,6 +127,10 @@ android {
             initWith(getByName("release"))
             applicationIdSuffix = ".preview"
             resValue("string", "app_name", "Kitchen on fire")
+            // Injected by CI from GitHub secrets; empty when building locally.
+            buildConfigField("String", "PREVIEW_SERVER_URL", "\"${project.findProperty("previewUrl") ?: ""}\"")
+            buildConfigField("String", "PREVIEW_EMAIL", "\"${project.findProperty("previewUser") ?: ""}\"")
+            buildConfigField("String", "PREVIEW_PASSWORD", "\"${project.findProperty("previewPass") ?: ""}\"")
         }
         debug {
             applicationIdSuffix = ".debug"

--- a/androidApp/src/main/kotlin/com/ultraviolince/mykitchen/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/ultraviolince/mykitchen/MainActivity.kt
@@ -4,12 +4,22 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import com.ultraviolince.mykitchen.ui.App
+import com.ultraviolince.mykitchen.ui.DefaultCredentials
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val defaultCredentials = BuildConfig.PREVIEW_SERVER_URL
+            .takeIf { it.isNotEmpty() }
+            ?.let {
+                DefaultCredentials(
+                    serverUrl = BuildConfig.PREVIEW_SERVER_URL,
+                    email = BuildConfig.PREVIEW_EMAIL,
+                    password = BuildConfig.PREVIEW_PASSWORD,
+                )
+            }
         setContent {
-            App()
+            App(defaultCredentials = defaultCredentials)
         }
     }
 }

--- a/desktopApp/src/main/kotlin/com/ultraviolince/mykitchen/Main.kt
+++ b/desktopApp/src/main/kotlin/com/ultraviolince/mykitchen/Main.kt
@@ -6,10 +6,25 @@ import com.ultraviolince.mykitchen.data.di.dataModule
 import com.ultraviolince.mykitchen.data.di.platformDataModule
 import com.ultraviolince.mykitchen.domain.di.domainModule
 import com.ultraviolince.mykitchen.ui.App
+import com.ultraviolince.mykitchen.ui.DefaultCredentials
 import com.ultraviolince.mykitchen.ui.di.uiModule
 import org.koin.core.context.startKoin
 
-fun main() {
+fun main(args: Array<String>) {
+    val argMap = args
+        .filter { it.startsWith("--") && it.contains("=") }
+        .associate { arg ->
+            val eq = arg.indexOf('=')
+            arg.substring(2, eq) to arg.substring(eq + 1)
+        }
+    val defaultCredentials = argMap.takeIf { it.isNotEmpty() }?.let {
+        DefaultCredentials(
+            serverUrl = it["url"],
+            email = it["user"],
+            password = it["pass"],
+        )
+    }
+
     startKoin {
         modules(platformDataModule, dataModule, domainModule, uiModule)
     }
@@ -18,7 +33,7 @@ fun main() {
             onCloseRequest = ::exitApplication,
             title = "My Kitchen",
         ) {
-            App()
+            App(defaultCredentials = defaultCredentials)
         }
     }
 }

--- a/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/App.kt
+++ b/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/App.kt
@@ -14,8 +14,14 @@ import com.ultraviolince.mykitchen.ui.screens.login.LoginScreen
 import com.ultraviolince.mykitchen.ui.screens.recipelist.RecipeListScreen
 import com.ultraviolince.mykitchen.ui.theme.AppTheme
 
+data class DefaultCredentials(
+    val serverUrl: String? = null,
+    val email: String? = null,
+    val password: String? = null,
+)
+
 @Composable
-fun App() {
+fun App(defaultCredentials: DefaultCredentials? = null) {
     SingletonImageLoader.setSafe { context ->
         ImageLoader.Builder(context)
             .components { add(KtorNetworkFetcherFactory()) }
@@ -44,6 +50,7 @@ fun App() {
             }
             composable<Route.Login> {
                 LoginScreen(
+                    defaultCredentials = defaultCredentials,
                     onLoginSuccess = {
                         navController.navigate(Route.RecipeList) {
                             popUpTo(Route.Login) { inclusive = true }

--- a/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/login/LoginScreen.kt
+++ b/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/login/LoginScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
+import com.ultraviolince.mykitchen.ui.DefaultCredentials
 import com.ultraviolince.mykitchen.ui.generated.resources.Res
 import com.ultraviolince.mykitchen.ui.generated.resources.email_hint
 import com.ultraviolince.mykitchen.ui.generated.resources.login_heading
@@ -39,9 +40,16 @@ import org.koin.compose.viewmodel.koinViewModel
 @Composable
 fun LoginScreen(
     onLoginSuccess: () -> Unit,
+    defaultCredentials: DefaultCredentials? = null,
     viewModel: LoginViewModel = koinViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(Unit) {
+        if (defaultCredentials != null) {
+            viewModel.applyDefaultCredentials(defaultCredentials)
+        }
+    }
 
     LaunchedEffect(state.isLoggedIn) {
         if (state.isLoggedIn) onLoginSuccess()

--- a/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/login/LoginViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/login/LoginViewModel.kt
@@ -3,6 +3,7 @@ package com.ultraviolince.mykitchen.ui.screens.login
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ultraviolince.mykitchen.domain.usecase.LoginUseCase
+import com.ultraviolince.mykitchen.ui.DefaultCredentials
 import com.ultraviolince.mykitchen.ui.generated.resources.Res
 import com.ultraviolince.mykitchen.ui.generated.resources.error_fields_required
 import com.ultraviolince.mykitchen.ui.generated.resources.error_login_failed
@@ -39,6 +40,16 @@ class LoginViewModel(
 
     fun onServerUrlChange(url: String) {
         _state.update { it.copy(serverUrl = url, error = null) }
+    }
+
+    fun applyDefaultCredentials(credentials: DefaultCredentials) {
+        _state.update {
+            it.copy(
+                serverUrl = credentials.serverUrl ?: it.serverUrl,
+                email = credentials.email ?: it.email,
+                password = credentials.password ?: it.password,
+            )
+        }
     }
 
     fun login() {

--- a/webApp/src/wasmJsMain/kotlin/com/ultraviolince/mykitchen/Main.kt
+++ b/webApp/src/wasmJsMain/kotlin/com/ultraviolince/mykitchen/Main.kt
@@ -6,17 +6,37 @@ import com.ultraviolince.mykitchen.data.di.dataModule
 import com.ultraviolince.mykitchen.data.di.platformDataModule
 import com.ultraviolince.mykitchen.domain.di.domainModule
 import com.ultraviolince.mykitchen.ui.App
+import com.ultraviolince.mykitchen.ui.DefaultCredentials
 import com.ultraviolince.mykitchen.ui.di.uiModule
 import kotlinx.browser.document
+import kotlinx.browser.window
 import org.koin.core.context.startKoin
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
+    val queryParams = parseQueryParams()
+    val defaultCredentials = queryParams.takeIf { it.isNotEmpty() }?.let {
+        DefaultCredentials(
+            serverUrl = it["url"],
+            email = it["user"],
+            password = it["pass"],
+        )
+    }
+
     startKoin {
         modules(platformDataModule, dataModule, domainModule, uiModule)
     }
     ComposeViewport(document.body!!) {
-        App()
+        App(defaultCredentials = defaultCredentials)
     }
+}
+
+private fun parseQueryParams(): Map<String, String> {
+    val search = window.location.search.removePrefix("?")
+    if (search.isBlank()) return emptyMap()
+    return search.split("&").mapNotNull { param ->
+        val eq = param.indexOf('=')
+        if (eq < 0) null else param.substring(0, eq) to param.substring(eq + 1)
+    }.toMap()
 }
 


### PR DESCRIPTION
## Summary

- Adds a `DefaultCredentials` data class to the shared UI module; `App()` accepts it as an optional parameter (defaults to `null`, so all existing call sites are unaffected)
- `LoginScreen` / `LoginViewModel` apply the credentials via `LaunchedEffect` on first composition
- **Desktop**: pass `--url=`, `--user=`, `--pass=` CLI args
- **Web**: pass `?url=&user=&pass=` URL query params
- **Android preview build**: `BuildConfig.PREVIEW_SERVER_URL/EMAIL/PASSWORD` are injected from GitHub secrets `PREVIEW_URL` / `PREVIEW_USER` / `PREVIEW_PASS` at CI build time; empty strings in debug and release builds so they are fully inert

The test deployment user (`test@kitchen.local`) is automatically seeded in the kitchen-test stack on startup.

## Test plan

- [ ] CI green (build, web, ios, instrumentedtests, verify-screenshots, backend-image)
- [ ] Desktop: run with `--url=https://kitchen-test-api.ultraviolince.com --user=test@kitchen.local --pass=kitchen-test-123` and confirm fields are pre-filled
- [ ] Web: open `?url=...&user=...&pass=...` and confirm fields are pre-filled
- [ ] Android debug/release: confirm login screen is empty (no credentials injected)
- [ ] Android preview APK from next RC build: confirm fields pre-filled with kitchen-test credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)