### PR TITLE
feat: publish web app as Docker image to GHCR

### DIFF
--- a/.github/workflows/backend-image.yml
+++ b/.github/workflows/backend-image.yml
@@ -2,10 +2,10 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "prod" ]
     tags: [ 'v*.*.*' ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "prod" ]
   merge_group:
 
 env:

--- a/.github/workflows/web-image.yml
+++ b/.github/workflows/web-image.yml
@@ -1,0 +1,63 @@
+name: Web Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "main" ]
+  merge_group:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-web
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v4.1.2
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image with Buildx
+        id: build-and-push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: webApp/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/web-image.yml
+++ b/.github/workflows/web-image.yml
@@ -2,10 +2,10 @@ name: Web Docker Image CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "prod" ]
     tags: [ 'v*.*.*' ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "prod" ]
   merge_group:
 
 env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Use `scripts/validate-pr.sh` to run all locally-executable checks at once.
 3. **Do not declare success based on local checks alone** when the changed
    files fall into the CI-only category above. Push to the branch, wait for
    all GitHub Actions jobs (`build`, `web`, `ios`, `instrumentedtests`,
-   `verify-screenshots`, `backend-image`) to turn green, and only then report
+   `verify-screenshots`, `backend-image`, `web-image`) to turn green, and only then report
    the task as done.
 
 4. **When editing `androidApp/build.gradle.kts`**, remember that Kotlin script
@@ -105,6 +105,7 @@ scripts/             validate-pr.sh and pre-commit-hook.sh
 | `ios` | macos | iOS framework linking (arm64 + simulator) |
 | `instrumentedtests` | ubuntu (emulator) | Android instrumented tests, API 28/31/34/35/36 |
 | `verify-screenshots` | ubuntu | Roborazzi screenshot regression tests |
-| `backend-image` | ubuntu | Docker build + push |
+| `backend-image` | ubuntu | Docker build + push (server) |
+| `web-image` | ubuntu | Docker build + push (web) |
 
 All jobs must be green before a PR is merged.

--- a/webApp/Dockerfile
+++ b/webApp/Dockerfile
@@ -1,5 +1,7 @@
 # Build stage — compiles the Kotlin/WasmJs web distribution
 FROM eclipse-temurin:17-jdk-jammy AS builder
+# libatomic1 is required by Node.js v25+ (downloaded by kotlinWasmToolingSetup)
+RUN apt-get update && apt-get install -y --no-install-recommends libatomic1 && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY . .
 RUN ./gradlew :webApp:wasmJsBrowserDistribution --no-daemon --no-configuration-cache

--- a/webApp/Dockerfile
+++ b/webApp/Dockerfile
@@ -1,0 +1,10 @@
+# Build stage — compiles the Kotlin/WasmJs web distribution
+FROM eclipse-temurin:17-jdk-jammy AS builder
+WORKDIR /app
+COPY . .
+RUN ./gradlew :webApp:wasmJsBrowserDistribution --no-daemon --no-configuration-cache
+
+# Runtime stage — Nginx serving the static files
+FROM nginx:alpine
+COPY --from=builder /app/webApp/build/dist/wasmJs/productionExecutable /usr/share/nginx/html
+EXPOSE 80


### PR DESCRIPTION
## Summary

- Add `webApp/Dockerfile` — multi-stage build: Gradle compiles the Kotlin/WasmJs distribution, then `nginx:alpine` serves the static files
- Add `.github/workflows/web-image.yml` — mirrors `backend-image.yml`, publishes `ghcr.io/violinyanev/my-kitchen-web` on pushes to `main`/`prod` and version tags
- Update `backend-image.yml` to also trigger on the `prod` branch (both images now fire consistently on `main` and `prod`)

## Test plan

- [ ] CI `web-image` job builds successfully on this PR
- [ ] After merge to `main`, verify `ghcr.io/violinyanev/my-kitchen-web:main` appears in GitHub Packages
- [ ] Confirm `backend-image` still builds correctly (trigger rules changed but logic unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)