### PR TITLE
chore: sync prod with main

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Set up JDK 17
       uses: actions/setup-java@v5

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -25,7 +25,7 @@ jobs:
         distribution: 'temurin'
 
     - name: Setup Android SDK
-      uses: android-actions/setup-android@v3
+      uses: android-actions/setup-android@v4
 
     - name: Grant execute permission to gradlew
       run: chmod +x gradlew

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,9 +2,9 @@ name: Performance Benchmarks
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, prod ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, prod ]
   schedule:
     - cron: '0 2 * * 0'
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -60,7 +60,7 @@ jobs:
           -Pandroid.testInstrumentationRunnerArguments.class=com.ultraviolince.mykitchen.macrobenchmark.BaselineProfileGenerator
 
     - name: Upload benchmark reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: benchmark-reports
@@ -69,7 +69,7 @@ jobs:
           macrobenchmark/build/outputs/connected_android_test_additional_output/
 
     - name: Upload baseline profiles
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: baseline-profiles

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,7 +51,7 @@ jobs:
             :shared:domain:compileKotlinDesktop \
             :shared:data:compileKotlinDesktop \
             :server:compileKotlin \
-            --no-daemon --stacktrace
+            --no-daemon --stacktrace --no-build-cache
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/deploy-web-app.yml
+++ b/.github/workflows/deploy-web-app.yml
@@ -43,7 +43,10 @@ jobs:
       uses: actions/configure-pages@v6
 
     - name: Build web app (WasmJs)
-      run: ./gradlew :webApp:wasmJsBrowserDistribution --warning-mode=fail
+      # --warning-mode=fail is intentionally absent: Kover 0.9.8 (PrepareKover.kt:29) and
+      # AGP (VariantDependenciesBuilder.java:279) both emit "Project object as dependency
+      # notation" deprecations internally. Both are tracked upstream; neither has a patch yet.
+      run: ./gradlew :webApp:wasmJsBrowserDistribution
 
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -104,7 +104,10 @@ jobs:
       run: |
         ./gradlew :androidApp:assemblePreview \
           -PversionCode=${{ steps.release_info.outputs.version_code }} \
-          -PversionName=${{ steps.release_info.outputs.version_name }}
+          -PversionName=${{ steps.release_info.outputs.version_name }} \
+          -PpreviewUrl=${{ secrets.PREVIEW_URL }} \
+          -PpreviewUser=${{ secrets.PREVIEW_USER }} \
+          -PpreviewPass=${{ secrets.PREVIEW_PASS }}
 
     - name: Build APK for tag release
       if: steps.release_info.outputs.is_tag_release == 'true'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -155,6 +155,7 @@ jobs:
         DATABASE_URL: jdbc:postgresql://localhost:5432/mykitchen
         DATABASE_USER: mykitchen
         DATABASE_PASSWORD: mykitchen
+        DEV_MODE: "true"
 
     - name: Wait for server to be ready
       run: |
@@ -267,6 +268,7 @@ jobs:
         DATABASE_URL: jdbc:postgresql://localhost:5432/mykitchen
         DATABASE_USER: mykitchen
         DATABASE_PASSWORD: mykitchen
+        DEV_MODE: "true"
 
     - name: Wait for server to be ready
       run: |

--- a/.github/workflows/web-image.yml
+++ b/.github/workflows/web-image.yml
@@ -1,4 +1,4 @@
-name: Docker Image CI
+name: Web Docker Image CI
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ${{ github.repository }}-web
 
 
 jobs:
@@ -55,7 +55,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: server/Dockerfile
+          file: webApp/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,194 @@
+# Tech Debt Backlog
+
+Generated: 2026-07-11. Covers shared code, server, androidApp, desktopApp, webApp, iosApp.
+
+---
+
+## HIGH — Fix First
+
+### H1 · Unsafe `!!` operators in RecipeRepositoryImpl
+**File:** `shared/data/src/commonMain/kotlin/com/ultraviolince/mykitchen/data/repository/RecipeRepositoryImpl.kt:49,51,66`
+`exceptionOrNull()!!` and `getOrNull()!!` crash if their assumed preconditions are violated.
+Replace with `.getOrElse { handleError() }` / early return patterns.
+
+### H2 · No unit tests for ViewModels
+**Files:** `shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/addedit/AddEditViewModel.kt`, `LoginViewModel.kt`, `RecipeListViewModel.kt`
+~275 lines of business logic with zero test coverage. The `shared:ui` module is explicitly excluded from Kover.
+Add 20–30 tests covering state transitions, error paths, and side effects.
+
+### H3 · No rate limiting on auth endpoints
+**File:** `server/src/main/kotlin/com/ultraviolince/mykitchen/server/routes/AuthRoutes.kt:28,70`
+Login and register routes accept unlimited attempts — brute force is trivially easy.
+Add a Ktor rate-limiting plugin or per-IP/per-email throttle middleware.
+
+### H4 · Silent exception suppression in EnrichmentService
+**File:** `server/src/main/kotlin/com/ultraviolince/mykitchen/server/data/services/EnrichmentService.kt:142,186`
+`catch (_: Exception)` swallows all errors and returns null with no logging.
+At minimum log the exception; ideally propagate typed errors so callers can distinguish failures.
+
+### H5 · CORS allows any origin when ENV var is absent
+**File:** `server/src/main/kotlin/com/ultraviolince/mykitchen/server/plugins/Cors.kt:21-22`
+If `origins` ENV var is unset in production, `anyHost()` is silently applied.
+Fail-safe: require the ENV var in production; throw on startup if missing and not dev mode.
+
+### H6 · No error feedback when deleting a recipe fails
+**File:** `shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/recipelist/RecipeListViewModel.kt:91-93`
+`delete(id)` launches a coroutine with no error capture; failures are silently ignored.
+Wrap in try/catch and emit an error state the UI can surface.
+
+### H7 · Background AutoBeautifyWorker can die silently
+**File:** `server/src/main/kotlin/com/ultraviolince/mykitchen/server/Application.kt:30`
+`launch { AutoBeautifyWorker(...).run() }` at root scope — an uncaught exception kills the worker with no restart.
+Use a supervised scope with a restart loop and exponential backoff.
+
+---
+
+## MEDIUM — Address Soon
+
+### M1 · Hardcoded `localhost:5000` default in LoginState
+**File:** `shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/login/LoginViewModel.kt:20`
+`val serverUrl: String = "http://localhost:5000"` leaks dev config into production builds.
+Drive from BuildConfig or a per-platform default that is overridable.
+
+### M2 · Hardcoded Ollama URL and model name
+**File:** `server/src/main/kotlin/com/ultraviolince/mykitchen/server/config/AppConfig.kt:37-38`
+`ollamaBaseUrl` and `ollamaModel` are compile-time strings.
+Make them ENV-backed with documented defaults.
+
+### M3 · `allTags` / `visibleRecipes` recomputed on every access (O(n²))
+**File:** `shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/recipelist/RecipeListViewModel.kt:35-36`
+`flatten().distinct().sorted()` called inside a derived StateFlow with no memoisation.
+Cache in a `val` computed once per upstream emission; move heavy derivation to the data layer if possible.
+
+### M4 · Multiple `collectAsState()` calls cause independent recompositions
+**File:** `shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/recipelist/RecipeListScreen.kt:67-68`
+Two independent `collectAsState()` calls mean state changes to either flow independently recompose the screen.
+Combine into a single `StateFlow` holding a screen-level UiState.
+
+### M5 · RecipeListScreen exceeds 200-line guideline
+**File:** `shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/recipelist/RecipeListScreen.kt` (247 lines)
+`OrderToggle`, `TagFilterRow`, and `RecipeItem` are composables defined inline that should live in their own file.
+Extract to `recipelist/components/` to reduce recomposition scope and improve reuse.
+
+### M6 · Duplicated coroutine error-handling boilerplate across ViewModels
+**Files:** `AddEditViewModel.kt`, `LoginViewModel.kt`, `RecipeListViewModel.kt`
+Each ViewModel repeats the same `viewModelScope.launch { … }` + error-state-update block.
+Extract to a shared `safelaunch { }` extension on `ViewModel` in a shared module.
+
+### M7 · Two `RecipeEntity.kt` files — incomplete KMP abstraction
+**Files:** `shared/data/src/commonMain/` + `nonWasmMain/`
+Platform-specific Room entity definitions suggest the KMP abstraction boundary is blurry.
+Consolidate via `expect`/`actual` or lift shared structure to a common sealed class.
+
+### M8 · Missing content-length validation for recipe text
+**Files:** `shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/addedit/AddEditScreen.kt`, `AddRecipeUseCase.kt:9`
+`OutlinedTextField` accepts unbounded input; `AddRecipeUseCase` only checks `isBlank()`.
+Add a max-length check (e.g., 10 000 chars) in the use case and reflect the count in the UI.
+
+### M9 · No URL format validation before login attempt
+**File:** `shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/login/LoginScreen.kt`
+Server URL field accepts any string; invalid URLs produce a confusing network error.
+Validate URL format in `LoginUseCase` or ViewModel and emit a typed error state.
+
+### M10 · Email validation only server-side
+**File:** `server/src/main/kotlin/com/ultraviolince/mykitchen/server/routes/AuthRoutes.kt:21-24`
+Client `LoginUseCase` only checks `isBlank()`; email regex lives on the server.
+Add lightweight email format check client-side for immediate UI feedback.
+
+### M11 · Keystore signing silently omitted if `keystore.properties` is absent
+**File:** `androidApp/build.gradle.kts:85-99`
+Release builds compile without signing when the file is missing; no error is thrown.
+Fail the build explicitly when `isCI` is true and keystore config is absent.
+
+### M12 · `PREVIEW_*` BuildConfig fields empty in local builds
+**File:** `androidApp/build.gradle.kts:131-133`
+CI injects credentials; local builds silently get empty strings.
+Document this in CLAUDE.md and add a Gradle warning when building `preview` variant locally.
+
+### M13 · No KDoc on domain use cases or repository interfaces
+**Files:** `shared/domain/src/commonMain/kotlin/com/ultraviolince/mykitchen/domain/usecase/*.kt`, `domain/repository/*.kt`
+~10 use case classes and 2 repository interfaces have no documentation on contracts, exceptions, or async behaviour.
+Add minimal KDoc covering: what it does, expected errors, and threading contract.
+
+### M14 · Server routes have no endpoint documentation
+**Files:** `server/src/main/kotlin/com/ultraviolince/mykitchen/server/routes/*.kt`
+No KDoc, no OpenAPI schema, no status-code documentation.
+Consider generating OpenAPI docs via `ktor-openapi` or add inline KDoc as a minimum.
+
+### M15 · No contract tests for platform CredentialsStore implementations
+**Files:** `shared/data/src/androidMain/`, `desktopMain/`, `iosMain/`, `wasmJsMain/` — `PlatformDataModule.kt`
+Four separate stores (SharedPreferences, keystore, Keychain, localStorage) share no test doubles.
+Write a common contract test suite and run it on each platform in CI.
+
+### M16 · Missing contentDescription on AsyncImage
+**File:** `shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/addedit/BeautifiedRecipeView.kt:56`
+Image credit string used inconsistently as content description.
+Set an explicit `contentDescription` string resource.
+
+### M17 · Login form fields lack semantic accessibility labels
+**File:** `shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/login/LoginScreen.kt`
+`testTag` is set but `semantics { contentDescription }` is not, so TalkBack reads placeholder text only.
+Add explicit label semantics to all input fields.
+
+### M18 · JWT secret not validated for minimum entropy
+**File:** `server/src/main/kotlin/com/ultraviolince/mykitchen/server/config/AppConfig.kt:22-23`
+`JWT_SECRET` ENV var is accepted regardless of length; a 1-character secret is allowed.
+Enforce minimum length (≥ 32 chars) on startup and fail fast if not met.
+
+---
+
+## LOW — Fix When Convenient
+
+### L1 · Client data layer has no logging
+**Files:** `shared/data/src/commonMain/kotlin/com/ultraviolince/mykitchen/data/`
+API client and repositories are completely silent; remote failures are opaque in production.
+Add structured logging (e.g., `co.touchlab:kermit`) at DEBUG level for network calls and errors.
+
+### L2 · ViewModels have no logging
+**Files:** `shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/**ViewModel.kt`
+Failed login, sync errors etc. are emitted to Snackbar but not persisted to logs.
+Log key state transitions at INFO and errors at ERROR level.
+
+### L3 · Inconsistent use case naming (noun vs. verb)
+**Files:** `shared/domain/src/commonMain/kotlin/com/ultraviolince/mykitchen/domain/usecase/*.kt`
+`LoginUseCase` / `LogoutUseCase` (noun) vs `AddRecipeUseCase` / `DeleteRecipeUseCase` (verb).
+Pick one convention (recommend verb-noun: `AddRecipeUseCase`) and rename across the board.
+
+### L4 · Inconsistent DTO serialisation style
+**File:** `shared/data/src/commonMain/kotlin/com/ultraviolince/mykitchen/data/remote/dto/RecipeDto.kt:11-12`
+`created_at` / `updated_at` use `@SerialName`; `id`, `title`, `content` do not.
+Apply `@SerialName` consistently or configure the serializer to use snake_case globally.
+
+### L5 · Localhost URL repeated ~12 times in tests
+**Files:** `shared/data/src/commonTest/kotlin/com/ultraviolince/mykitchen/data/`
+Hardcoded `"http://localhost:5000"` scattered across multiple test files.
+Extract to a `TestConstants` object in `commonTest`.
+
+### L6 · No explicit tab order in RecipeListScreen
+**File:** `shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/recipelist/RecipeListScreen.kt`
+Compose uses layout order by default; no explicit `Modifier.focusOrder` or semantic traversal.
+Audit and define expected keyboard/switch-access navigation path.
+
+### L7 · Desktop and Web build configs are stubs
+**Files:** `desktopApp/build.gradle.kts`, `webApp/build.gradle.kts`
+Both are minimal with no run configuration, resource management, or platform-specific settings.
+Align with androidApp config structure and document any intentional omissions.
+
+### L8 · Unsplash API key could leak in error traces
+**File:** `server/src/main/kotlin/com/ultraviolince/mykitchen/server/config/AppConfig.kt:39`
+`unsplashAccessKey` is read from ENV correctly but no sanitisation prevents it appearing in logs.
+Add a Logback masking pattern or a custom `toString()` that redacts the key.
+
+---
+
+## Done / Not an Issue
+
+| Item | Status |
+|------|--------|
+| TODO/FIXME/HACK/XXX comments | None found — clean |
+| Deprecated API usage | None found — clean |
+| Outdated dependencies | All current (Kotlin 2.3.20, Ktor 3.5.1, Compose 1.11.1, Koin 4.2.2, Room 3.0.0) |
+| Renovate configured | Yes — `renovate.json` present |
+| Server-side logging | Present via SLF4J/Logback — good |
+| `key = { it.id }` in LazyColumn | Already in place — good |
+| Input validation at server boundary | UUID parsing wrapped in exception handler — acceptable |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Use `scripts/validate-pr.sh` to run all locally-executable checks at once.
 3. **Do not declare success based on local checks alone** when the changed
    files fall into the CI-only category above. Push to the branch, wait for
    all GitHub Actions jobs (`build`, `web`, `ios`, `instrumentedtests`,
-   `verify-screenshots`, `backend-image`) to turn green, and only then report
+   `verify-screenshots`, `backend-image`, `web-image`) to turn green, and only then report
    the task as done.
 
 4. **When editing `androidApp/build.gradle.kts`**, remember that Kotlin script
@@ -105,6 +105,7 @@ scripts/             validate-pr.sh and pre-commit-hook.sh
 | `ios` | macos | iOS framework linking (arm64 + simulator) |
 | `instrumentedtests` | ubuntu (emulator) | Android instrumented tests, API 28/31/34/35/36 |
 | `verify-screenshots` | ubuntu | Roborazzi screenshot regression tests |
-| `backend-image` | ubuntu | Docker build + push |
+| `backend-image` | ubuntu | Docker build + push (server) |
+| `web-image` | ubuntu | Docker build + push (web) |
 
 All jobs must be green before a PR is merged.

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -79,6 +79,7 @@ android {
         // AGP 9.x disables resValues by default; build types use resValue() for
         // per-variant app names, so this must be explicitly enabled.
         resValues = true
+        buildConfig = true
     }
 
     val keystorePropertiesFile = rootProject.file("keystore.properties")
@@ -105,6 +106,10 @@ android {
         versionCode = project.findProperty("versionCode")?.toString()?.toInt() ?: 1
         versionName = project.findProperty("versionName")?.toString() ?: "2.0.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        // Empty defaults so all build types always have these fields.
+        buildConfigField("String", "PREVIEW_SERVER_URL", "\"\"")
+        buildConfigField("String", "PREVIEW_EMAIL", "\"\"")
+        buildConfigField("String", "PREVIEW_PASSWORD", "\"\"")
     }
 
     buildTypes {
@@ -122,6 +127,10 @@ android {
             initWith(getByName("release"))
             applicationIdSuffix = ".preview"
             resValue("string", "app_name", "Kitchen on fire")
+            // Injected by CI from GitHub secrets; empty when building locally.
+            buildConfigField("String", "PREVIEW_SERVER_URL", "\"${project.findProperty("previewUrl") ?: ""}\"")
+            buildConfigField("String", "PREVIEW_EMAIL", "\"${project.findProperty("previewUser") ?: ""}\"")
+            buildConfigField("String", "PREVIEW_PASSWORD", "\"${project.findProperty("previewPass") ?: ""}\"")
         }
         debug {
             applicationIdSuffix = ".debug"

--- a/androidApp/src/main/kotlin/com/ultraviolince/mykitchen/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/ultraviolince/mykitchen/MainActivity.kt
@@ -4,12 +4,22 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import com.ultraviolince.mykitchen.ui.App
+import com.ultraviolince.mykitchen.ui.DefaultCredentials
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val defaultCredentials = BuildConfig.PREVIEW_SERVER_URL
+            .takeIf { it.isNotEmpty() }
+            ?.let {
+                DefaultCredentials(
+                    serverUrl = BuildConfig.PREVIEW_SERVER_URL,
+                    email = BuildConfig.PREVIEW_EMAIL,
+                    password = BuildConfig.PREVIEW_PASSWORD,
+                )
+            }
         setContent {
-            App()
+            App(defaultCredentials = defaultCredentials)
         }
     }
 }

--- a/androidApp/src/main/kotlin/com/ultraviolince/mykitchen/MyKitchenApp.kt
+++ b/androidApp/src/main/kotlin/com/ultraviolince/mykitchen/MyKitchenApp.kt
@@ -1,6 +1,7 @@
 package com.ultraviolince.mykitchen
 
 import android.app.Application
+import android.os.StrictMode
 import com.ultraviolince.mykitchen.data.di.dataModule
 import com.ultraviolince.mykitchen.data.di.platformDataModule
 import com.ultraviolince.mykitchen.domain.di.domainModule
@@ -12,6 +13,10 @@ import org.koin.core.context.startKoin
 class MyKitchenApp : Application() {
     override fun onCreate() {
         super.onCreate()
+
+        // Initialize StrictMode early to catch violations throughout the app lifecycle
+        initializeStrictMode()
+
         // Robolectric resets the Application between tests but Koin's global state
         // persists in JVM statics — guard against re-starting an already-running instance.
         if (GlobalContext.getOrNull() == null) {
@@ -20,5 +25,99 @@ class MyKitchenApp : Application() {
                 modules(platformDataModule, dataModule, domainModule, uiModule)
             }
         }
+    }
+
+    private fun initializeStrictMode() {
+        // Check if running in test mode to avoid crashing during instrumented tests
+        val isTestMode = isRunningInTestMode()
+
+        if (BuildConfig.DEBUG) {
+            // Enable comprehensive StrictMode for debug builds
+            enableDebugStrictMode(isTestMode)
+        } else {
+            // Enable minimal StrictMode for release builds to catch critical issues
+            enableReleaseStrictMode(isTestMode)
+        }
+    }
+
+    private fun isRunningInTestMode(): Boolean {
+        // Check if we're running under instrumentation or testing framework
+        return try {
+            Class.forName("androidx.test.espresso.Espresso") != null ||
+                Class.forName("org.junit.runner.Runner") != null ||
+                Class.forName("androidx.test.runner.AndroidJUnitRunner") != null ||
+                System.getProperty("java.class.path")?.contains("test") == true
+        } catch (e: ClassNotFoundException) {
+            false
+        }
+    }
+
+    private fun enableDebugStrictMode(isTestMode: Boolean) {
+        // Thread policy - detect main thread violations
+        val threadPolicyBuilder = StrictMode.ThreadPolicy.Builder()
+            .detectDiskReads()
+            .detectDiskWrites()
+            .detectNetwork()
+            .detectCustomSlowCalls()
+            .detectResourceMismatches()
+
+        if (isTestMode) {
+            // In test mode, use logging instead of death penalty to avoid test crashes
+            threadPolicyBuilder
+                .penaltyLog()
+                .penaltyFlashScreen() // Visual indication for developers
+        } else {
+            // In normal debug mode, use death penalty for strict enforcement
+            threadPolicyBuilder
+                .penaltyDeath()
+                .penaltyFlashScreen() // Visual indication for developers
+        }
+
+        StrictMode.setThreadPolicy(threadPolicyBuilder.build())
+
+        // VM policy - detect memory leaks and resource violations
+        val vmPolicyBuilder = StrictMode.VmPolicy.Builder()
+            .detectActivityLeaks()
+            .detectLeakedSqlLiteObjects()
+            .detectLeakedClosableObjects()
+            .detectLeakedRegistrationObjects()
+            .detectFileUriExposure()
+            .detectCleartextNetwork()
+            .detectContentUriWithoutPermission()
+            .detectUntaggedSockets()
+
+        if (isTestMode) {
+            // In test mode, use logging instead of death penalty
+            vmPolicyBuilder.penaltyLog()
+        } else {
+            // In normal debug mode, use death penalty for strict enforcement
+            vmPolicyBuilder.penaltyDeath()
+        }
+
+        StrictMode.setVmPolicy(vmPolicyBuilder.build())
+    }
+
+    private fun enableReleaseStrictMode(isTestMode: Boolean) {
+        // Minimal StrictMode for release builds - only critical violations
+        val threadPolicyBuilder = StrictMode.ThreadPolicy.Builder()
+            .detectNetwork() // Network on main thread is always critical
+
+        val vmPolicyBuilder = StrictMode.VmPolicy.Builder()
+            .detectActivityLeaks() // Memory leaks are critical
+            .detectLeakedSqlLiteObjects()
+            .detectCleartextNetwork() // Security issue
+
+        if (isTestMode) {
+            // In test mode, use logging instead of death penalty even for release builds
+            threadPolicyBuilder.penaltyLog()
+            vmPolicyBuilder.penaltyLog()
+        } else {
+            // In normal release mode, use death penalty for critical violations
+            threadPolicyBuilder.penaltyDeath()
+            vmPolicyBuilder.penaltyDeath()
+        }
+
+        StrictMode.setThreadPolicy(threadPolicyBuilder.build())
+        StrictMode.setVmPolicy(vmPolicyBuilder.build())
     }
 }

--- a/androidApp/src/test/kotlin/com/ultraviolince/mykitchen/MyKitchenAppTest.kt
+++ b/androidApp/src/test/kotlin/com/ultraviolince/mykitchen/MyKitchenAppTest.kt
@@ -1,0 +1,57 @@
+package com.ultraviolince.mykitchen
+
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class MyKitchenAppTest {
+
+    @Test
+    fun `app has strictMode initialization methods`() {
+        val app = MyKitchenApp()
+
+        // Use reflection to verify the StrictMode methods exist
+        val initializeStrictModeMethod = app.javaClass.getDeclaredMethod("initializeStrictMode")
+        assertNotNull("initializeStrictMode method should exist", initializeStrictModeMethod)
+
+        val isRunningInTestModeMethod = app.javaClass.getDeclaredMethod("isRunningInTestMode")
+        assertNotNull("isRunningInTestMode method should exist", isRunningInTestModeMethod)
+
+        val enableDebugStrictModeMethod = app.javaClass.getDeclaredMethod(
+            "enableDebugStrictMode",
+            Boolean::class.java
+        )
+        assertNotNull("enableDebugStrictMode method should exist", enableDebugStrictModeMethod)
+
+        val enableReleaseStrictModeMethod = app.javaClass.getDeclaredMethod(
+            "enableReleaseStrictMode",
+            Boolean::class.java
+        )
+        assertNotNull("enableReleaseStrictMode method should exist", enableReleaseStrictModeMethod)
+    }
+
+    @Test
+    fun `app buildConfig has debug field`() {
+        // Verify BuildConfig.DEBUG field exists and is accessible
+        val buildConfigClass = Class.forName("com.ultraviolince.mykitchen.BuildConfig")
+        val debugField = buildConfigClass.getField("DEBUG")
+        assertNotNull("BuildConfig.DEBUG field should exist", debugField)
+
+        // The value can be either true or false depending on build variant
+        val debugValue = debugField.get(null)
+        assertNotNull("DEBUG field should have a value", debugValue)
+    }
+
+    @Test
+    fun `app strictMode classes are accessible`() {
+        // Verify StrictMode classes are available at runtime
+        assertNotNull("StrictMode class should be available", Class.forName("android.os.StrictMode"))
+        assertNotNull(
+            "ThreadPolicy.Builder should be available",
+            Class.forName("android.os.StrictMode\$ThreadPolicy\$Builder")
+        )
+        assertNotNull(
+            "VmPolicy.Builder should be available",
+            Class.forName("android.os.StrictMode\$VmPolicy\$Builder")
+        )
+    }
+}

--- a/desktopApp/src/main/kotlin/com/ultraviolince/mykitchen/Main.kt
+++ b/desktopApp/src/main/kotlin/com/ultraviolince/mykitchen/Main.kt
@@ -6,10 +6,25 @@ import com.ultraviolince.mykitchen.data.di.dataModule
 import com.ultraviolince.mykitchen.data.di.platformDataModule
 import com.ultraviolince.mykitchen.domain.di.domainModule
 import com.ultraviolince.mykitchen.ui.App
+import com.ultraviolince.mykitchen.ui.DefaultCredentials
 import com.ultraviolince.mykitchen.ui.di.uiModule
 import org.koin.core.context.startKoin
 
-fun main() {
+fun main(args: Array<String>) {
+    val argMap = args
+        .filter { it.startsWith("--") && it.contains("=") }
+        .associate { arg ->
+            val eq = arg.indexOf('=')
+            arg.substring(2, eq) to arg.substring(eq + 1)
+        }
+    val defaultCredentials = argMap.takeIf { it.isNotEmpty() }?.let {
+        DefaultCredentials(
+            serverUrl = it["url"],
+            email = it["user"],
+            password = it["pass"],
+        )
+    }
+
     startKoin {
         modules(platformDataModule, dataModule, domainModule, uiModule)
     }
@@ -18,7 +33,7 @@ fun main() {
             onCloseRequest = ::exitApplication,
             title = "My Kitchen",
         ) {
-            App()
+            App(defaultCredentials = defaultCredentials)
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ bcrypt = "0.10.2"
 
 # Benchmarking
 macrobenchmark = "1.3.3"
-uiautomator = "2.3.0"
+uiautomator = "2.4.0"
 
 # Testing
 junit = "4.13.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ kotlinxCoroutines = "1.11.0"
 bcrypt = "0.10.2"
 
 # Benchmarking
-macrobenchmark = "1.3.3"
+macrobenchmark = "1.4.1"
 uiautomator = "2.4.0"
 
 # Testing

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - DATABASE_PASSWORD=mykitchen
       - DATABASE_DRIVER=org.postgresql.Driver
       - JWT_SECRET=${JWT_SECRET:?JWT_SECRET is required}
+      - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:?CORS_ALLOWED_ORIGINS is required (comma-separated list of allowed origins)}
     depends_on:
       db:
         condition: service_healthy

--- a/server/src/main/kotlin/com/ultraviolince/mykitchen/server/config/AppConfig.kt
+++ b/server/src/main/kotlin/com/ultraviolince/mykitchen/server/config/AppConfig.kt
@@ -16,6 +16,8 @@ data class AppConfig(
     val ollamaModel: String,
     /** Null disables Unsplash image fetching (enrichments still work without images). */
     val unsplashAccessKey: String?,
+    /** True only in local development; allows omitting CORS_ALLOWED_ORIGINS. Set DEV_MODE=true to enable. */
+    val devMode: Boolean = false,
 ) {
     companion object {
         fun fromEnvironment(): AppConfig = AppConfig(
@@ -37,6 +39,7 @@ data class AppConfig(
             ollamaBaseUrl = System.getenv("OLLAMA_BASE_URL") ?: "http://ollama:11434",
             ollamaModel = System.getenv("OLLAMA_MODEL") ?: "gemma4:26b",
             unsplashAccessKey = System.getenv("UNSPLASH_ACCESS_KEY"),
+            devMode = System.getenv("DEV_MODE")?.lowercase() == "true",
         )
     }
 }

--- a/server/src/main/kotlin/com/ultraviolince/mykitchen/server/data/services/EnrichmentService.kt
+++ b/server/src/main/kotlin/com/ultraviolince/mykitchen/server/data/services/EnrichmentService.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import org.slf4j.LoggerFactory
 import java.net.URI
 import java.net.URLEncoder
 import java.net.http.HttpClient
@@ -26,6 +27,8 @@ import java.time.Duration
  * [EnrichmentJsonResponse].
  */
 class EnrichmentService(private val config: AppConfig) {
+
+    private val logger = LoggerFactory.getLogger(EnrichmentService::class.java)
 
     private val httpClient: HttpClient = HttpClient.newBuilder()
         .connectTimeout(Duration.ofSeconds(10))
@@ -139,7 +142,12 @@ class EnrichmentService(private val config: AppConfig) {
     ): EnrichmentResult {
         val parsed = try {
             json.decodeFromString<EnrichmentJsonResponse>(extractJson(responseText))
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            logger.error(
+                "Failed to parse LLM JSON response (parse error: ${e::class.simpleName}); " +
+                    "falling back to raw text summary. Response was: ${responseText.take(200)}",
+                e,
+            )
             EnrichmentJsonResponse(summary = responseText.take(500))
         }
 
@@ -183,7 +191,15 @@ class EnrichmentService(private val config: AppConfig) {
                 val credit = result["user"]?.jsonObject?.get("name")?.jsonPrimitive?.content
 
                 imageUrl to credit
-            } catch (_: Exception) {
+            } catch (e: java.io.IOException) {
+                logger.error("Network error fetching Unsplash image for query \"$query\"", e)
+                null to null
+            } catch (e: Exception) {
+                logger.error(
+                    "Failed to fetch or parse Unsplash image for query \"$query\" " +
+                        "(${e::class.simpleName})",
+                    e,
+                )
                 null to null
             }
         }

--- a/server/src/main/kotlin/com/ultraviolince/mykitchen/server/plugins/Cors.kt
+++ b/server/src/main/kotlin/com/ultraviolince/mykitchen/server/plugins/Cors.kt
@@ -19,6 +19,10 @@ fun Application.configureCors(config: AppConfig) {
         allowHeader(HttpHeaders.ContentType)
         val origins = config.corsAllowedOrigins
         if (origins == null) {
+            check(config.devMode) {
+                "CORS_ALLOWED_ORIGINS must be set in production. " +
+                    "Set DEV_MODE=true only for local development to allow any origin."
+            }
             anyHost()
         } else {
             origins.forEach { origin ->

--- a/server/src/test/kotlin/com/ultraviolince/mykitchen/server/ServerTest.kt
+++ b/server/src/test/kotlin/com/ultraviolince/mykitchen/server/ServerTest.kt
@@ -61,6 +61,7 @@ class ServerTest {
         ollamaBaseUrl = "http://localhost:11434",
         ollamaModel = "gemma4:26b",
         unsplashAccessKey = null,
+        devMode = true,
     )
 
     @BeforeTest
@@ -478,14 +479,35 @@ class ServerTest {
     }
 
     @Test
-    fun configureCorsWithNullOriginsAllowsAnyHost() = testApplication {
+    fun configureCorsWithNullOriginsAndDevModeAllowsAnyHost() = testApplication {
         application {
             configureSerialization()
-            configureCors(testConfig)
+            configureCors(testConfig) // testConfig has devMode=true and corsAllowedOrigins=null
             routing { healthRoutes() }
         }
         val response = client.get("/health")
         assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun configureCorsWithNullOriginsAndProdModeThrows() {
+        val prodConfig = testConfig.copy(devMode = false, corsAllowedOrigins = null)
+        var caughtException: IllegalStateException? = null
+        try {
+            testApplication {
+                application {
+                    configureSerialization()
+                    configureCors(prodConfig)
+                    routing { healthRoutes() }
+                }
+                // Trigger startup by making a request
+                client.get("/health")
+            }
+        } catch (e: IllegalStateException) {
+            caughtException = e
+        }
+        assertNotNull(caughtException)
+        assertTrue(caughtException.message!!.contains("CORS_ALLOWED_ORIGINS"))
     }
 
     @Test

--- a/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/App.kt
+++ b/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/App.kt
@@ -14,8 +14,14 @@ import com.ultraviolince.mykitchen.ui.screens.login.LoginScreen
 import com.ultraviolince.mykitchen.ui.screens.recipelist.RecipeListScreen
 import com.ultraviolince.mykitchen.ui.theme.AppTheme
 
+data class DefaultCredentials(
+    val serverUrl: String? = null,
+    val email: String? = null,
+    val password: String? = null,
+)
+
 @Composable
-fun App() {
+fun App(defaultCredentials: DefaultCredentials? = null) {
     SingletonImageLoader.setSafe { context ->
         ImageLoader.Builder(context)
             .components { add(KtorNetworkFetcherFactory()) }
@@ -44,6 +50,7 @@ fun App() {
             }
             composable<Route.Login> {
                 LoginScreen(
+                    defaultCredentials = defaultCredentials,
                     onLoginSuccess = {
                         navController.navigate(Route.RecipeList) {
                             popUpTo(Route.Login) { inclusive = true }

--- a/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/login/LoginScreen.kt
+++ b/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/login/LoginScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
+import com.ultraviolince.mykitchen.ui.DefaultCredentials
 import com.ultraviolince.mykitchen.ui.generated.resources.Res
 import com.ultraviolince.mykitchen.ui.generated.resources.email_hint
 import com.ultraviolince.mykitchen.ui.generated.resources.login_heading
@@ -39,9 +40,16 @@ import org.koin.compose.viewmodel.koinViewModel
 @Composable
 fun LoginScreen(
     onLoginSuccess: () -> Unit,
+    defaultCredentials: DefaultCredentials? = null,
     viewModel: LoginViewModel = koinViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(Unit) {
+        if (defaultCredentials != null) {
+            viewModel.applyDefaultCredentials(defaultCredentials)
+        }
+    }
 
     LaunchedEffect(state.isLoggedIn) {
         if (state.isLoggedIn) onLoginSuccess()

--- a/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/login/LoginViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/login/LoginViewModel.kt
@@ -3,6 +3,7 @@ package com.ultraviolince.mykitchen.ui.screens.login
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ultraviolince.mykitchen.domain.usecase.LoginUseCase
+import com.ultraviolince.mykitchen.ui.DefaultCredentials
 import com.ultraviolince.mykitchen.ui.generated.resources.Res
 import com.ultraviolince.mykitchen.ui.generated.resources.error_fields_required
 import com.ultraviolince.mykitchen.ui.generated.resources.error_login_failed
@@ -39,6 +40,16 @@ class LoginViewModel(
 
     fun onServerUrlChange(url: String) {
         _state.update { it.copy(serverUrl = url, error = null) }
+    }
+
+    fun applyDefaultCredentials(credentials: DefaultCredentials) {
+        _state.update {
+            it.copy(
+                serverUrl = credentials.serverUrl ?: it.serverUrl,
+                email = credentials.email ?: it.email,
+                password = credentials.password ?: it.password,
+            )
+        }
     }
 
     fun login() {

--- a/webApp/Dockerfile
+++ b/webApp/Dockerfile
@@ -1,0 +1,12 @@
+# Build stage — compiles the Kotlin/WasmJs web distribution
+FROM eclipse-temurin:17-jdk-jammy AS builder
+# libatomic1 is required by Node.js v25+ (downloaded by kotlinWasmToolingSetup)
+RUN apt-get update && apt-get install -y --no-install-recommends libatomic1 && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY . .
+RUN ./gradlew :webApp:wasmJsBrowserDistribution --no-daemon --no-configuration-cache
+
+# Runtime stage — Nginx serving the static files
+FROM nginx:alpine
+COPY --from=builder /app/webApp/build/dist/wasmJs/productionExecutable /usr/share/nginx/html
+EXPOSE 80

--- a/webApp/src/wasmJsMain/kotlin/com/ultraviolince/mykitchen/Main.kt
+++ b/webApp/src/wasmJsMain/kotlin/com/ultraviolince/mykitchen/Main.kt
@@ -6,17 +6,37 @@ import com.ultraviolince.mykitchen.data.di.dataModule
 import com.ultraviolince.mykitchen.data.di.platformDataModule
 import com.ultraviolince.mykitchen.domain.di.domainModule
 import com.ultraviolince.mykitchen.ui.App
+import com.ultraviolince.mykitchen.ui.DefaultCredentials
 import com.ultraviolince.mykitchen.ui.di.uiModule
 import kotlinx.browser.document
+import kotlinx.browser.window
 import org.koin.core.context.startKoin
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
+    val queryParams = parseQueryParams()
+    val defaultCredentials = queryParams.takeIf { it.isNotEmpty() }?.let {
+        DefaultCredentials(
+            serverUrl = it["url"],
+            email = it["user"],
+            password = it["pass"],
+        )
+    }
+
     startKoin {
         modules(platformDataModule, dataModule, domainModule, uiModule)
     }
     ComposeViewport(document.body!!) {
-        App()
+        App(defaultCredentials = defaultCredentials)
     }
+}
+
+private fun parseQueryParams(): Map<String, String> {
+    val search = window.location.search.removePrefix("?")
+    if (search.isBlank()) return emptyMap()
+    return search.split("&").mapNotNull { param ->
+        val eq = param.indexOf('=')
+        if (eq < 0) null else param.substring(0, eq) to param.substring(eq + 1)
+    }.toMap()
 }
 


### PR DESCRIPTION
## Summary

Brings `prod` up to date with `main`. Includes all changes merged since the last prod sync:

- feat: publish web app as Docker image to GHCR (#842)
- feat: prefill login credentials via launch parameters (#841)
- fix(server): fail safe when CORS origins ENV var is absent (#833)
- fix(server): log suppressed exceptions in EnrichmentService (#825)
- fix(deps): various dependency updates (#829, #830)
- chore(deps): various tooling updates (#834, #835, #839, #840)
- docs: add tech debt backlog (#836)
- fix(ci): disable Gradle build cache for CodeQL manual build (#838)

## Test plan

- [ ] All CI checks pass on this PR
- [ ] After merge, verify prod branch is at the same commit as main

🤖 Generated with [Claude Code](https://claude.com/claude-code)