### PR TITLE
feat: block recipe creation when server is unreachable

### DIFF
--- a/.claude/skills/ensure-tests/SKILL.md
+++ b/.claude/skills/ensure-tests/SKILL.md
@@ -76,6 +76,36 @@ Key points:
 - Create local `private class FakeXxxRepo : XxxRepository` inline — test fakes from other modules aren't accessible
 - `kotlinx.coroutines.test` is declared in `libs.versions.toml`; add `testImplementation(libs.kotlinx.coroutines.test)` to `androidApp/build.gradle.kts` if not present
 
+### Screenshot (golden) tests — `@Preview` functions
+
+Every meaningful **visual state** of a screen needs a `@Preview` in `shared/ui/src/androidMain/.../screens/<screen>/<Screen>Previews.kt`. Roborazzi auto-converts these into golden screenshot tests via `generateComposePreviewRobolectricTests`.
+
+```kotlin
+@OptIn(ExperimentalResourceApi::class)
+@Preview(showBackground = true, name = "My Screen — Error State")
+@Composable
+internal fun MyScreenErrorPreview() {
+    val ctx = LocalContext.current
+    remember(ctx) { setResourceReaderAndroidContext(ctx) }
+    AppTheme {
+        MyScreenContent(
+            state = MyState(isError = true),
+            onAction = {},
+        )
+    }
+}
+```
+
+**How goldens are recorded:** The `verify-screenshots` CI job runs `verifyAndRecordRoborazziDebug`. When a new `@Preview` has no golden yet, the job records it, then auto-commits the new image file to the PR branch with the message "Updated Roborazzi screenshots after verification" and posts a PR comment. No manual step needed — just push the preview and let CI handle it.
+
+**When goldens must be re-recorded:** If existing UI changes cause a visual diff, the `verify-screenshots` job fails and the same auto-commit mechanism updates the affected goldens. Review the committed diff to confirm the change was intentional.
+
+Goldens live in `androidApp/src/test/screenshots/` and are committed to the repo (tracked by git).
+
+**Rule of thumb:** For every new state you add to `RecipeListState`, `AddEditState`, or any other screen state, add a `@Preview` for it. Behavioral tests (`createComposeRule`) check logic; `@Preview` + roborazzi checks visual appearance.
+
+---
+
 ### Compose UI tests (`androidApp/src/test/`)
 
 Test the `*Content` composable (the stateless one), not the screen that wires the ViewModel:
@@ -129,6 +159,7 @@ For each changed component, ask:
 - [ ] Default / happy-path state renders key elements
 - [ ] Error / unreachable / loading states show the right UI
 - [ ] User actions (button clicks) call the right callback — and blocked actions don't
+- [ ] A `@Preview` exists in `*Previews.kt` for every new visual state (roborazzi turns these into golden screenshot tests automatically)
 
 ---
 

--- a/.claude/skills/ensure-tests/SKILL.md
+++ b/.claude/skills/ensure-tests/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: ensure-tests
+description: Ensure unit tests and UI tests are added or updated when implementing new features, fixing bugs, or changing behavior in the my-kitchen KMP project. Use this skill whenever new ViewModels, use cases, repository methods, or Compose screens are added or modified — even if the user doesn't explicitly ask for tests. Also use when the user asks to "add tests", "write tests for this", or "make sure this is tested".
+---
+
+# Ensure Tests — my-kitchen
+
+When a feature lands, two questions must be answered before the task is done:
+1. Is the **logic** tested? (ViewModel state transitions, use-case outcomes, repository behavior)
+2. Is the **UI** tested? (screen renders correctly for each meaningful state)
+
+Work through both, write the missing tests, and confirm they pass locally.
+
+---
+
+## Where tests live
+
+| What changed | Test location | Runner |
+|---|---|---|
+| Domain use case (`shared/domain/`) | `shared/domain/src/commonTest/` | `kotlin.test` + `runTest` |
+| Data repository (`shared/data/`) | `shared/data/src/commonTest/` | `kotlin.test` + `runTest` |
+| ViewModel (`shared/ui/`) | `androidApp/src/test/` | Robolectric (`ScreenshotTestRunner`) |
+| Compose screen (`shared/ui/`) | `androidApp/src/test/` | Robolectric (`ScreenshotTestRunner`) |
+
+`shared/ui` has no `commonTest` source set — ViewModel and Compose tests both go in `androidApp/src/test/`.
+
+---
+
+## Test patterns
+
+### Domain use-case tests (`shared/domain/src/commonTest/`)
+
+```kotlin
+class MyUseCaseTest {
+    @Test
+    fun `returns success when repo succeeds`() = runTest {
+        val repo = FakeRecipeRepository()
+        repo.syncResult = Result.success(Unit)
+        val result = MyUseCase(repo)()
+        assertTrue(result.isSuccess)
+    }
+}
+```
+
+- Import `kotlin.test.*` for assertions (`assertTrue`, `assertEquals`, `assertFails`)
+- Use `FakeRecipeRepository` from the same `commonTest` package (already exists)
+- Use `kotlinx.coroutines.test.runTest` for suspend functions
+- Collect flows with `.first()` (from `kotlinx.coroutines.flow`)
+
+### ViewModel unit tests (`androidApp/src/test/`)
+
+```kotlin
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(ScreenshotTestRunner::class)
+class MyViewModelTest {
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @Before fun setUp() { Dispatchers.setMain(testDispatcher) }
+    @After fun tearDown() { Dispatchers.resetMain() }
+
+    @Test
+    fun `state change after action`() = runTest {
+        val repo = FakeRepo()
+        val vm = MyViewModel(MyUseCase(repo))
+        vm.doSomething()
+        advanceUntilIdle()
+        assertEquals(expectedState, vm.state.value)
+    }
+}
+```
+
+Key points:
+- Always `setMain(UnconfinedTestDispatcher())` — `viewModelScope` needs a Main dispatcher
+- Always `resetMain()` in `@After`
+- `advanceUntilIdle()` after any ViewModel action that launches coroutines
+- Create local `private class FakeXxxRepo : XxxRepository` inline — test fakes from other modules aren't accessible
+- `kotlinx.coroutines.test` is declared in `libs.versions.toml`; add `testImplementation(libs.kotlinx.coroutines.test)` to `androidApp/build.gradle.kts` if not present
+
+### Compose UI tests (`androidApp/src/test/`)
+
+Test the `*Content` composable (the stateless one), not the screen that wires the ViewModel:
+
+```kotlin
+@OptIn(ExperimentalResourceApi::class)
+@RunWith(ScreenshotTestRunner::class)
+class MyScreenTest {
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Test
+    fun `element is shown in correct state`() {
+        composeTestRule.setContent {
+            val ctx = LocalContext.current
+            remember(ctx) { setResourceReaderAndroidContext(ctx) }
+            AppTheme {
+                MyScreenContent(
+                    state = MyState(/* meaningful fields */),
+                    onAction = {},
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("Expected text").assertIsDisplayed()
+    }
+}
+```
+
+Use these finders/matchers:
+- `onNodeWithText("…")` / `onNodeWithContentDescription("…")`
+- `.assertIsDisplayed()`, `.assertIsNotDisplayed()`, `.assertDoesNotExist()`
+- `.performClick()` — then assert a callback was or wasn't called via a `var clicked = false` flag
+
+---
+
+## Checklist when a feature is added
+
+For each changed component, ask:
+
+**Use case?**
+- [ ] Happy path (success result)
+- [ ] Failure path (error result / exception)
+- [ ] Edge cases mentioned in the task
+
+**ViewModel?**
+- [ ] Initial state is correct
+- [ ] State after each public action (`fun doX()`) is correct
+- [ ] Failure in the use case produces the right error state
+- [ ] Side effects (navigation triggers, logout, etc.) fire when expected
+
+**Compose screen?**
+- [ ] Default / happy-path state renders key elements
+- [ ] Error / unreachable / loading states show the right UI
+- [ ] User actions (button clicks) call the right callback — and blocked actions don't
+
+---
+
+## What to run locally after writing tests
+
+```bash
+# Detekt + domain/data unit tests + server compile — always runnable
+./scripts/validate-pr.sh
+
+# ViewModel and Compose tests need CI (AGP/Robolectric require Google Maven)
+# Push and let the `build` and `verify-screenshots` CI jobs validate them
+```
+
+Changes to `androidApp/build.gradle.kts` (e.g. adding a test dependency) are CI-only — see CLAUDE.md.
+
+---
+
+## Common pitfalls
+
+- **Don't share test fakes across modules.** `FakeRecipeRepository` in `shared/domain/src/commonTest/` is invisible to `androidApp/src/test/`. Duplicate only what the test needs, keeping the fake minimal.
+- **Don't forget `resetMain()`.** Leaving a test dispatcher set leaks into other tests.
+- **String resources in Compose tests** require `setResourceReaderAndroidContext(ctx)` inside `setContent {}` — without it, string lookups throw at test time.
+- **Screenshot tests** (`verify-screenshots` CI job) record golden images; if a screen's appearance changes, the job will fail until goldens are re-recorded with `./gradlew :androidApp:recordRoborazziDebug` (CI-only). If your test is not a screenshot test, use `createComposeRule()` not `createAndroidComposeRule()` to avoid auto-capture.

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -181,6 +181,7 @@ dependencies {
     debugImplementation(libs.compose.ui.test.manifest)
 
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.androidx.test.ext.junit)
     testImplementation(libs.compose.ui.test.junit4)
     testImplementation(libs.roborazzi)

--- a/androidApp/src/test/kotlin/com/ultraviolince/mykitchen/RecipeListScreenTest.kt
+++ b/androidApp/src/test/kotlin/com/ultraviolince/mykitchen/RecipeListScreenTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import com.ultraviolince.mykitchen.domain.model.Recipe
 import com.ultraviolince.mykitchen.domain.model.RecipeOrder
 import com.ultraviolince.mykitchen.ui.screens.recipelist.RecipeListScreenContent
@@ -13,6 +14,8 @@ import com.ultraviolince.mykitchen.ui.screens.recipelist.RecipeListState
 import com.ultraviolince.mykitchen.ui.theme.AppTheme
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.setResourceReaderAndroidContext
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -78,5 +81,81 @@ class RecipeListScreenTest {
         composeTestRule.onNodeWithContentDescription("Sync").assertIsDisplayed()
         composeTestRule.onNodeWithContentDescription("Logout").assertIsDisplayed()
         composeTestRule.onNodeWithText("No recipes yet. Tap + to add one.").assertIsDisplayed()
+    }
+
+    @OptIn(ExperimentalResourceApi::class)
+    @Test
+    fun serverUnreachable_bannerIsShown() {
+        composeTestRule.setContent {
+            val ctx = LocalContext.current
+            remember(ctx) { setResourceReaderAndroidContext(ctx) }
+            AppTheme {
+                RecipeListScreenContent(
+                    state = RecipeListState(isServerReachable = false),
+                    onAddRecipe = {},
+                    onEditRecipe = {},
+                    onSync = {},
+                    onLogout = {},
+                    onDelete = {},
+                    onOrderChange = {},
+                    onTagSelect = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(
+            "Server unreachable — adding recipes is disabled until sync succeeds.",
+            substring = true,
+        ).assertIsDisplayed()
+    }
+
+    @OptIn(ExperimentalResourceApi::class)
+    @Test
+    fun serverUnreachable_fabClickDoesNotTriggerNavigation() {
+        var addRecipeCalled = false
+        composeTestRule.setContent {
+            val ctx = LocalContext.current
+            remember(ctx) { setResourceReaderAndroidContext(ctx) }
+            AppTheme {
+                RecipeListScreenContent(
+                    state = RecipeListState(isServerReachable = false),
+                    onAddRecipe = { addRecipeCalled = true },
+                    onEditRecipe = {},
+                    onSync = {},
+                    onLogout = {},
+                    onDelete = {},
+                    onOrderChange = {},
+                    onTagSelect = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("Add recipe").performClick()
+        assertFalse("FAB should not navigate when server is unreachable", addRecipeCalled)
+    }
+
+    @OptIn(ExperimentalResourceApi::class)
+    @Test
+    fun serverReachable_fabClickTriggersNavigation() {
+        var addRecipeCalled = false
+        composeTestRule.setContent {
+            val ctx = LocalContext.current
+            remember(ctx) { setResourceReaderAndroidContext(ctx) }
+            AppTheme {
+                RecipeListScreenContent(
+                    state = RecipeListState(isServerReachable = true),
+                    onAddRecipe = { addRecipeCalled = true },
+                    onEditRecipe = {},
+                    onSync = {},
+                    onLogout = {},
+                    onDelete = {},
+                    onOrderChange = {},
+                    onTagSelect = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("Add recipe").performClick()
+        assertTrue("FAB should navigate when server is reachable", addRecipeCalled)
     }
 }

--- a/androidApp/src/test/kotlin/com/ultraviolince/mykitchen/RecipeListViewModelTest.kt
+++ b/androidApp/src/test/kotlin/com/ultraviolince/mykitchen/RecipeListViewModelTest.kt
@@ -1,0 +1,144 @@
+package com.ultraviolince.mykitchen
+
+import com.ultraviolince.mykitchen.domain.model.AuthState
+import com.ultraviolince.mykitchen.domain.model.Recipe
+import com.ultraviolince.mykitchen.domain.model.RecipeEnrichment
+import com.ultraviolince.mykitchen.domain.model.RecipeOrder
+import com.ultraviolince.mykitchen.domain.model.SessionExpiredException
+import com.ultraviolince.mykitchen.domain.model.User
+import com.ultraviolince.mykitchen.domain.repository.EnrichmentRepository
+import com.ultraviolince.mykitchen.domain.repository.RecipeRepository
+import com.ultraviolince.mykitchen.domain.usecase.DeleteRecipeUseCase
+import com.ultraviolince.mykitchen.domain.usecase.GetAuthStateUseCase
+import com.ultraviolince.mykitchen.domain.usecase.GetEnrichmentsUseCase
+import com.ultraviolince.mykitchen.domain.usecase.GetRecipesUseCase
+import com.ultraviolince.mykitchen.domain.usecase.LogoutUseCase
+import com.ultraviolince.mykitchen.domain.usecase.SyncRecipesUseCase
+import com.ultraviolince.mykitchen.ui.screens.recipelist.RecipeListViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(ScreenshotTestRunner::class)
+class RecipeListViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun buildViewModel(
+        syncResult: Result<Unit> = Result.success(Unit),
+    ): Pair<RecipeListViewModel, FakeRecipeRepo> {
+        val repo = FakeRecipeRepo(syncResult = syncResult)
+        val vm = RecipeListViewModel(
+            getRecipes = GetRecipesUseCase(repo),
+            deleteRecipe = DeleteRecipeUseCase(repo),
+            syncRecipes = SyncRecipesUseCase(repo),
+            logout = LogoutUseCase(repo),
+            getAuthState = GetAuthStateUseCase(repo),
+            getEnrichments = GetEnrichmentsUseCase(FakeEnrichmentRepo()),
+        )
+        return vm to repo
+    }
+
+    @Test
+    fun `sync success keeps isServerReachable true and clears error`() = runTest {
+        val (vm, _) = buildViewModel(syncResult = Result.success(Unit))
+        vm.sync()
+        advanceUntilIdle()
+        assertTrue(vm.state.value.isServerReachable)
+        assertNull(vm.state.value.error)
+    }
+
+    @Test
+    fun `sync network failure sets isServerReachable to false and shows error`() = runTest {
+        val (vm, _) = buildViewModel(syncResult = Result.failure(Exception("Connection refused")))
+        vm.sync()
+        advanceUntilIdle()
+        assertFalse(vm.state.value.isServerReachable)
+        assertNotNull(vm.state.value.error)
+    }
+
+    @Test
+    fun `sync SessionExpiredException triggers logout`() = runTest {
+        val (vm, repo) = buildViewModel(syncResult = Result.failure(SessionExpiredException()))
+        vm.sync()
+        advanceUntilIdle()
+        assertEquals(AuthState.LoggedOut, repo.authFlow.value)
+    }
+
+    @Test
+    fun `sync SessionExpiredException does not set isServerReachable false`() = runTest {
+        val (vm, _) = buildViewModel(syncResult = Result.failure(SessionExpiredException()))
+        vm.sync()
+        advanceUntilIdle()
+        // Session expiry triggers logout, not the server-unreachable banner
+        assertTrue(vm.state.value.isServerReachable)
+    }
+
+    @Test
+    fun `isServerReachable recovers to true after a successful sync follows a failed one`() = runTest {
+        val repo = FakeRecipeRepo(syncResult = Result.failure(Exception("down")))
+        val vm = RecipeListViewModel(
+            getRecipes = GetRecipesUseCase(repo),
+            deleteRecipe = DeleteRecipeUseCase(repo),
+            syncRecipes = SyncRecipesUseCase(repo),
+            logout = LogoutUseCase(repo),
+            getAuthState = GetAuthStateUseCase(repo),
+            getEnrichments = GetEnrichmentsUseCase(FakeEnrichmentRepo()),
+        )
+        vm.sync()
+        advanceUntilIdle()
+        assertFalse(vm.state.value.isServerReachable)
+
+        repo.syncResult = Result.success(Unit)
+        vm.sync()
+        advanceUntilIdle()
+        assertTrue(vm.state.value.isServerReachable)
+        assertNull(vm.state.value.error)
+    }
+}
+
+private class FakeRecipeRepo(var syncResult: Result<Unit>) : RecipeRepository {
+    val authFlow = MutableStateFlow<AuthState>(
+        AuthState.LoggedIn(User(email = "test@test.com", serverUrl = "http://localhost", token = "tok"))
+    )
+
+    override fun getRecipes(order: RecipeOrder): Flow<List<Recipe>> = MutableStateFlow(emptyList())
+    override suspend fun getRecipeById(id: String): Recipe? = null
+    override suspend fun insertRecipe(recipe: Recipe) {}
+    override suspend fun deleteRecipe(id: String) {}
+    override suspend fun syncRecipes(): Result<Unit> = syncResult
+    override suspend fun login(email: String, password: String, serverUrl: String) = Result.success(Unit)
+    override suspend fun logout() { authFlow.value = AuthState.LoggedOut }
+    override fun getAuthState(): Flow<AuthState> = authFlow
+}
+
+private class FakeEnrichmentRepo : EnrichmentRepository {
+    override suspend fun getEnrichment(recipeId: String) = Result.success<RecipeEnrichment?>(null)
+    override suspend fun getEnrichments() = Result.success(emptyList<RecipeEnrichment>())
+}

--- a/androidApp/src/test/screenshots/com.ultraviolince.mykitchen.ui.screens.recipelist.RecipeListScreenPreviewsKt.RecipeListScreenServerUnreachablePreview.Recipe_List_—_Server_Unreachable_WITH_BACKGROUND.png
+++ b/androidApp/src/test/screenshots/com.ultraviolince.mykitchen.ui.screens.recipelist.RecipeListScreenPreviewsKt.RecipeListScreenServerUnreachablePreview.Recipe_List_—_Server_Unreachable_WITH_BACKGROUND.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9be7d637974c6c166861d59eb9b1847d28d07933eab4e6c396d2128d5bfd0590
+size 54458

--- a/shared/data/src/commonMain/kotlin/com/ultraviolince/mykitchen/data/repository/RecipeRepositoryImpl.kt
+++ b/shared/data/src/commonMain/kotlin/com/ultraviolince/mykitchen/data/repository/RecipeRepositoryImpl.kt
@@ -7,7 +7,10 @@ import com.ultraviolince.mykitchen.data.store.CredentialsStore
 import com.ultraviolince.mykitchen.domain.model.AuthState
 import com.ultraviolince.mykitchen.domain.model.Recipe
 import com.ultraviolince.mykitchen.domain.model.RecipeOrder
+import com.ultraviolince.mykitchen.domain.model.SessionExpiredException
 import com.ultraviolince.mykitchen.domain.model.User
+import io.ktor.client.plugins.ResponseException
+import io.ktor.http.HttpStatusCode
 import com.ultraviolince.mykitchen.domain.repository.RecipeRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -46,7 +49,12 @@ class RecipeRepositoryImpl(
             ?: return Result.failure(IllegalStateException("No server URL"))
 
         val remoteResult = api.getRecipes(serverUrl, token)
-        val remoteRecipes = remoteResult.getOrElse { return Result.failure(it) }
+        val remoteRecipes = remoteResult.getOrElse { error ->
+            if (error is ResponseException && error.response.status == HttpStatusCode.Unauthorized) {
+                return Result.failure(SessionExpiredException())
+            }
+            return Result.failure(error)
+        }
         remoteRecipes.forEach { dto -> dao.insert(dto.toDomain()) }
 
         val unsyncedIds = dao.getUnsyncedDeletedIds()

--- a/shared/domain/src/commonMain/kotlin/com/ultraviolince/mykitchen/domain/model/SessionExpiredException.kt
+++ b/shared/domain/src/commonMain/kotlin/com/ultraviolince/mykitchen/domain/model/SessionExpiredException.kt
@@ -1,0 +1,3 @@
+package com.ultraviolince.mykitchen.domain.model
+
+class SessionExpiredException : Exception("Session expired")

--- a/shared/ui/src/androidMain/kotlin/com/ultraviolince/mykitchen/ui/screens/recipelist/RecipeListScreenPreviews.kt
+++ b/shared/ui/src/androidMain/kotlin/com/ultraviolince/mykitchen/ui/screens/recipelist/RecipeListScreenPreviews.kt
@@ -61,6 +61,31 @@ internal fun RecipeListScreenWithItemsPreview() {
 }
 
 @OptIn(ExperimentalResourceApi::class)
+@Preview(showBackground = true, name = "Recipe List — Server Unreachable")
+@Composable
+internal fun RecipeListScreenServerUnreachablePreview() {
+    val ctx = LocalContext.current
+    remember(ctx) { setResourceReaderAndroidContext(ctx) }
+    AppTheme {
+        RecipeListScreenContent(
+            state = RecipeListState(
+                recipes = listOf(
+                    Recipe(id = "1", title = "Pasta Carbonara", content = "Classic Italian pasta dish", timestamp = 0L),
+                ),
+                isServerReachable = false,
+            ),
+            onAddRecipe = {},
+            onEditRecipe = {},
+            onSync = {},
+            onLogout = {},
+            onDelete = {},
+            onOrderChange = {},
+            onTagSelect = {},
+        )
+    }
+}
+
+@OptIn(ExperimentalResourceApi::class)
 @Preview(showBackground = true, name = "Phone — Recipe List", widthDp = 360, heightDp = 800)
 @Composable
 internal fun RecipeListScreenPhonePreview() {

--- a/shared/ui/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/ui/src/commonMain/composeResources/values-de/strings.xml
@@ -43,4 +43,5 @@
     <string name="error_login_failed">Anmeldung fehlgeschlagen. Bitte überprüfen Sie Ihre Anmeldedaten.</string>
     <string name="error_delete_failed">Löschen fehlgeschlagen. Bitte versuchen Sie es erneut.</string>
     <string name="error_sync_failed">Synchronisierung fehlgeschlagen. Bitte versuchen Sie es erneut.</string>
+    <string name="error_server_unreachable">Server nicht erreichbar — Rezepte hinzufügen ist deaktiviert bis die Synchronisierung erfolgreich ist.</string>
 </resources>

--- a/shared/ui/src/commonMain/composeResources/values/strings.xml
+++ b/shared/ui/src/commonMain/composeResources/values/strings.xml
@@ -43,4 +43,5 @@
     <string name="error_login_failed">Login failed. Please check your credentials.</string>
     <string name="error_delete_failed">Delete failed. Please try again.</string>
     <string name="error_sync_failed">Sync failed. Please try again.</string>
+    <string name="error_server_unreachable">Server unreachable — adding recipes is disabled until sync succeeds.</string>
 </resources>

--- a/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/recipelist/RecipeListScreen.kt
+++ b/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/recipelist/RecipeListScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -46,6 +47,7 @@ import com.ultraviolince.mykitchen.domain.model.RecipeOrder
 import com.ultraviolince.mykitchen.ui.generated.resources.Res
 import com.ultraviolince.mykitchen.ui.generated.resources.add_recipe
 import com.ultraviolince.mykitchen.ui.generated.resources.delete_recipe
+import com.ultraviolince.mykitchen.ui.generated.resources.error_server_unreachable
 import com.ultraviolince.mykitchen.ui.generated.resources.logout
 import com.ultraviolince.mykitchen.ui.generated.resources.no_recipes
 import com.ultraviolince.mykitchen.ui.generated.resources.sort_date
@@ -123,7 +125,13 @@ fun RecipeListScreenContent(
             )
         },
         floatingActionButton = {
-            FloatingActionButton(onClick = onAddRecipe) {
+            FloatingActionButton(
+                onClick = { if (state.isServerReachable) onAddRecipe() },
+                containerColor = if (state.isServerReachable)
+                    MaterialTheme.colorScheme.primaryContainer
+                else
+                    MaterialTheme.colorScheme.surfaceVariant,
+            ) {
                 Icon(Icons.Default.Add, contentDescription = stringResource(Res.string.add_recipe))
             }
         },
@@ -134,6 +142,19 @@ fun RecipeListScreenContent(
                 .fillMaxSize()
                 .padding(paddingValues),
         ) {
+            if (!state.isServerReachable) {
+                Surface(
+                    color = MaterialTheme.colorScheme.errorContainer,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        stringResource(Res.string.error_server_unreachable),
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                    )
+                }
+            }
             OrderToggle(
                 currentOrder = state.order,
                 onOrderChange = onOrderChange,

--- a/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/recipelist/RecipeListViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/ultraviolince/mykitchen/ui/screens/recipelist/RecipeListViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ultraviolince.mykitchen.domain.model.AuthState
 import com.ultraviolince.mykitchen.domain.model.Recipe
+import com.ultraviolince.mykitchen.domain.model.SessionExpiredException
 import com.ultraviolince.mykitchen.domain.model.RecipeOrder
 import com.ultraviolince.mykitchen.domain.usecase.DeleteRecipeUseCase
 import com.ultraviolince.mykitchen.domain.usecase.GetAuthStateUseCase
@@ -28,6 +29,7 @@ data class RecipeListState(
     val order: RecipeOrder = RecipeOrder.Date(),
     val isSyncing: Boolean = false,
     val error: StringResource? = null,
+    val isServerReachable: Boolean = true,
     /** Tags of each recipe's server-generated enrichment, keyed by recipe id. */
     val tagsByRecipe: Map<String, List<String>> = emptyMap(),
     val selectedTag: String? = null,
@@ -102,13 +104,18 @@ class RecipeListViewModel(
         viewModelScope.launch {
             _state.update { it.copy(isSyncing = true, error = null) }
             val result = syncRecipes()
+            if (result.exceptionOrNull() is SessionExpiredException) {
+                logout.invoke()
+                return@launch
+            }
             _state.update {
                 it.copy(
                     isSyncing = false,
+                    isServerReachable = result.isSuccess,
                     error = if (result.isFailure) Res.string.error_sync_failed else null,
                 )
             }
-            loadEnrichmentTags()
+            if (result.isSuccess) loadEnrichmentTags()
         }
     }
 


### PR DESCRIPTION
## Summary

- Detects HTTP 401 during sync and auto-logs out, so a stale/invalid session immediately redirects the user to the login screen instead of silently failing
- Tracks server reachability (`isServerReachable`) in `RecipeListState` after every sync
- Disables the Add Recipe FAB (greyed out, click is a no-op) and shows a red error banner when the server can't be reached, preventing the user from creating recipes that would be lost on re-login

## Motivation

If a user's session token becomes invalid (e.g. after a server DB wipe), recipes appeared to save locally but were silently dropped when sync failed. The user had no indication that their data was at risk.

## Test plan

- [ ] Login with a valid session → sync succeeds → FAB is active, no banner
- [ ] Simulate server down (stop the backend container) → sync fails → red banner appears, FAB is greyed out and non-clickable → restart backend → tap Refresh → banner disappears, FAB re-enables
- [ ] Login with a stale/invalid token → first sync returns 401 → app auto-logs out and navigates to login screen
- [ ] CI green on all jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)